### PR TITLE
Fix README formatting and bug in `--reset-chain` `join/joinTestnet.sh` argument.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,14 @@ To perform these tests, you'll need some test Bitcoins on the Bitcoin testnet, a
     axelarcli tx bitcoin link ethereum 0xc1c0c8D2131cC866834C6382096EaDFEf1af2F52 --from validator -y -b block
     ```
     Look for `chain: Bitcoin, address: {btcaddress}` and copy the btc address.
-2. External: send a TEST BTC on Bitcoin testnet to the deposit address specific above using https://testnet-faucet.mempool.co/, and wait for 6 confirmations (i.e. the transaction is 6 blocks deep in the Bitcoin chain).
-    - You can monitor the status of your deposit using the testnet explorer: https://blockstream.info/testnet/ .
-    - **NOTE**: Please ensure you are seeting 6 confirmations before moving to the next steps. Axelar network will verify until at least 6 confirmations.
-    - **ALERT**: DO NOT SEND ANY REAL ASSET.
+2. Deposit TEST BTC for conversion into ERC20 BTC into the address from the previous command's output.
+
+    You can choose to send to the TEST BTC to the specific deposit address above directly from the testnet faucet https://testnet-faucet.mempool.co/ or you can send TEST BTC from the faucet to your own testnet BTC wallet first and then forward only the amount you want to mint from your testnet BTC wallet to the specific deposit address above.
+
+    After depositing the TEST BTC wait for 6 confirmations (i.e. the transaction is 6 blocks deep in the Bitcoin chain).
+        - You can monitor the status of your deposit using the testnet explorer: https://blockstream.info/testnet/ .
+        - **NOTE**: Please ensure you are seeting 6 confirmations before moving to the next steps. Axelar network will verify until at least 6 confirmations.
+        - **ALERT**: DO NOT SEND ANY REAL ASSET.
 3. Create verification json object for Axelar
     ```
     axelarcli q bitcoin txInfo {blockhash} {txID}:{voutIdx}
@@ -140,7 +144,7 @@ To perform these tests, you'll need some test Bitcoins on the Bitcoin testnet, a
     ```
 5. Trigger signing of the transfers to Ethereum:
     ```
-    axelarcli tx ethereum sign-pending-transfers --from validator -y -b block
+    axelarcli tx ethereum sign-pending-transfers --gas="auto" --gas-adjustment=1.15 --from validator -y -b block
     -> returns commandID of signed tx
     -> wait for sign protocol to complete (~10 blocks)
     ```
@@ -166,9 +170,12 @@ To perform these tests, you'll need some test Bitcoins on the Bitcoin testnet, a
 
 To send wrapped Bitcoin back to Bitcoin, run the following commands:
 
-1. Create a deposit address on Ethereum
+1. Create a deposit address on Ethereum:
+
+    **Note**: The BTC testnet address here is where your testnet BTC will be withdrawn to. If you sent TEST BTC from your own wallet when minting the ERC20 wrapped Bitcoin above, then you should put your testnet BTC wallet address here as the withdrawal address, otherwise you should set the withrawal address to the faucet address (e.g. `mkHS9ne12qx9pS9VojpwU5xtRd4T7X7ZUt`) to send the TEST BTC back to the testnet faucet (https://testnet-faucet.mempool.co/).
+
     ```
-    axelarcli tx ethereum link bitcoin {bitcoin addr} satoshi --from validator -y -b block
+    axelarcli tx ethereum link bitcoin {bitcoin withdrawal addr} satoshi --from validator -y -b block
     -> returns deposit address
     ```
     e.g.,
@@ -195,12 +202,12 @@ To send wrapped Bitcoin back to Bitcoin, run the following commands:
     ```
 4. Trigger signing of all pending transfers to Bitcoin
     ```
-    axelarcli tx bitcoin sign-pending-transfers {tx fee} --from validator -b block -y
+    axelarcli tx bitcoin sign-pending-transfers {tx fee} --gas="auto" --gas-adjustment=1.15 --from validator -b block -y
     -> wait for sign protocol to complete (~10 Axelar blocks, 1 minute)
     ```
     e.g.,
     ```
-    axelarcli tx bitcoin sign-pending-transfers 0.0001btc --from validator -b block -y
+    axelarcli tx bitcoin sign-pending-transfers 0.0001btc --gas="auto" --gas-adjustment=1.15 --from validator -b block -y
     ```
 5. Submit the transfer to Bitcoin
     ```

--- a/README.md
+++ b/README.md
@@ -72,204 +72,160 @@ To perform these tests, you'll need some test Bitcoins on the Bitcoin testnet, a
 
 ### Generating a key on Axelar
 1. On a new terminal window, enter the Axelar node command line:
-
-```
-docker exec -it axelar-core sh
-```
-
+    ```
+    docker exec -it axelar-core sh
+    ```
 2. By default, the node has an account named validator. Find its address:
-
-```
-axelarcli keys show validator -a
-```
-
+    ```
+    axelarcli keys show validator -a
+    ```
 3. Go to axelar faucet and get some coins on your validator's address (Your node is not yet a validator for the purpose of this ceremony; it's just the name of the account). http://faucet.testnet.axelar.network/
-
 4. Check that you received the funds.
-
-NOTE: At this point, you should wait for your local Axelar node to fully catch up with the network, or the following commands will give errors. The average block time is ~5.6 sesconds, so if your local node is writing log messages such as `height=xxx` much faster, you should wait and come back in a few hours. 
-
-```
-axelarcli q account {validator_addr}
-```
-
-
+    NOTE: At this point, you should wait for your local Axelar node to fully catch up with the network, or the following commands will give errors. The average block time is ~5.6 sesconds, so if your local node is writing log messages such as `height=xxx` much faster, you should wait and come back in a few hours.
+    ```
+    axelarcli q account {validator_addr}
+    ```
 
 ### Mint ERC20 Bitcoin tokens on Ethereum
 
 1. Use Axelar to create a deposit address on Bitcoin testnet (to which you'll deposit coins later). You can connect your Metamask to Ropsten and copy your address, as this [example](https://axelar-static.s3.us-east-2.amazonaws.com/metamask-ropsten.png).
-
-  ```
-  axelarcli tx bitcoin link ethereum {ethereum Ropsten dst addr} --from validator -y -b block
--> returns deposit address
-  ```
-
-  e.g.,
-
-  ```
-  axelarcli tx bitcoin link ethereum 0xc1c0c8D2131cC866834C6382096EaDFEf1af2F52 --from validator -y -b block
-  ```
-
-  Look for `chain: Bitcoin, address: {btcaddress}` and copy the btc address.
-
-2. External: send a TEST BTC on Bitcoin testnet to the deposit address specific above using https://testnet-faucet.mempool.co/, and wait for 6 confirmations (i.e. the transaction is 6 blocks deep in the Bitcoin chain). 
-  - You can monitor the status of your deposit using the testnet explorer: https://blockstream.info/testnet/ .
-  - **NOTE**: Please ensure you are seeting 6 confirmations before moving to the next steps. Axelar network will verify until at least 6 confirmations.
-  - **ALERT**: DO NOT SEND ANY REAL ASSET.
-
+    ```
+    axelarcli tx bitcoin link ethereum {ethereum Ropsten dst addr} --from validator -y -b block
+    -> returns deposit address
+    ```
+    e.g.,
+    ```
+    axelarcli tx bitcoin link ethereum 0xc1c0c8D2131cC866834C6382096EaDFEf1af2F52 --from validator -y -b block
+    ```
+    Look for `chain: Bitcoin, address: {btcaddress}` and copy the btc address.
+2. External: send a TEST BTC on Bitcoin testnet to the deposit address specific above using https://testnet-faucet.mempool.co/, and wait for 6 confirmations (i.e. the transaction is 6 blocks deep in the Bitcoin chain).
+    - You can monitor the status of your deposit using the testnet explorer: https://blockstream.info/testnet/ .
+    - **NOTE**: Please ensure you are seeting 6 confirmations before moving to the next steps. Axelar network will verify until at least 6 confirmations.
+    - **ALERT**: DO NOT SEND ANY REAL ASSET.
 3. Create verification json object for Axelar
-
-  ```
-  axelarcli q bitcoin txInfo {blockhash} {txID}:{voutIdx}
-  -> returns json of verification info for the given outpoint (copy the escaped string)
-  ```
+    ```
+    axelarcli q bitcoin txInfo {blockhash} {txID}:{voutIdx}
+    -> returns json of verification info for the given outpoint (copy the escaped string)
+    ```
     e.g.,
+    ```
+    axelarcli q bitcoin txInfo 00000000000000162fb45caa03a03d0d9cfd1ef1158b231589f4014bc143faec  da5b2e8037ce4b95f40ada01c6c2cd3ccb806d0a952906130eb9b806f7887590:1
+    ```
+    See [here](https://axelar-static.s3.us-east-2.amazonaws.com/blockstream.png) for an example of where to find the arguments.
 
-  ```
-  axelarcli q bitcoin txInfo 00000000000000162fb45caa03a03d0d9cfd1ef1158b231589f4014bc143faec  da5b2e8037ce4b95f40ada01c6c2cd3ccb806d0a952906130eb9b806f7887590:1
-  ```
-  See [here](https://axelar-static.s3.us-east-2.amazonaws.com/blockstream.png) for an example of where to find the arguments.
+    Explanation of the arguments:
+        - txID: ID of the trasaction;
+        - blockhash: the hash of the block containing this transaction;
+        - voutIdx: the index of the vout (output portions of the transaction).
 
-Explanation of the arguments: 
-- txID: ID of the trasaction;
-- blockhash: the hash of the block containing this transaction;
-- voutIdx: the index of the vout (output portions of the transaction).
+    Copy the first line of the output, with the string escape characters.
 
-Copy the first line of the output, with the string escape characters.
     e.g.,
-
-  ```
-  {\"OutPoint\":{\"Hash\":\"CF/uMuFKIMVGJBu+OJ3TT2rG/pKCftubmiRRoCX9W9o=\",\"Index\":0},\"Amount\":\"100000\",\"BlockHash\":\"7PpDwUsB9IkVI4sV8R79nA09oAOqXLQvFgAAAAAAAAA=\",\"Address\":\"tb1qy0g49zge4kcajk7j2f9yamzeyzcmsgqpxnq4p29lyyjkcqv0fu0sta59cc\",\"Confirmations\":\"7\"}
-  ```
-
+    ```
+    {\"OutPoint\":{\"Hash\":\"CF/uMuFKIMVGJBu+OJ3TT2rG/pKCftubmiRRoCX9W9o=\",\"Index\":0},\"Amount\":\"100000\",\"BlockHash\":\"7PpDwUsB9IkVI4sV8R79nA09oAOqXLQvFgAAAAAAAAA=\",\"Address\":\"tb1qy0g49zge4kcajk7j2f9yamzeyzcmsgqpxnq4p29lyyjkcqv0fu0sta59cc\",\"Confirmations\":\"7\"}
+    ```
 4. Verify the Bitcoin outpoint using the copied verification info above
+    ```
+    axelarcli tx bitcoin verifyTx "{verification info}" --from validator -y -b block
+    ```
+    e.g.,
+    ```
+    axelarcli tx bitcoin verifyTx "{\"OutPoint\":{\"Hash\":\"NxF/hGLGQZ6mTNyMWkYHPJ21E+2PMb1DV/beV7R9Gpk=\",\"Index\":1},\"Amount\":\"100000000\",\"BlockHash\":\"tPqsKekDOp5lW6QUl+YwlaD/3cmbQJwuUqgiNkqloQM=\",\"Address\":\"bcrt1qrnc097fuepeyrchganj4jzl2yuf5c0fg800uenr5h0d58emztxasusnk7p\",\"Confirmations\":\"21\"}"}" --from validator -y -b block
+    ```
+    Wait for verification to be confirmed (~10 Axelar blocks, ~50 secs).
 
-  ```
-  axelarcli tx bitcoin verifyTx "{verification info}" --from validator -y -b block
-  ```
+    Eventually, you'll see something like this in the node terminal:
+    ```
+    threshold of 2/3 has been met for bitcoinVerifyTx7d097730bbeba835e21dc0d953d4b1c3e42a6bf0da03e70f01a6bb0c1b71183c:1:
+    ```
+5. Trigger signing of the transfers to Ethereum:
+    ```
+    axelarcli tx ethereum sign-pending-transfers --from validator -y -b block
+    -> returns commandID of signed tx
+    -> wait for sign protocol to complete (~10 blocks)
+    ```
+    Look for commandID and its value in the output:
+    ```
+    "key": "commandID", "value": "d5e993e407ff399cf2770a1d42bc2baf5308f46632fcbe209318acb09776599f"
+    ```
+6. Send the previous command to Ethereum:
+    ```
+    axelarcli q ethereum sendCommand {commandID} {address of account that should send this tx}
+    ```
+    e.g., for the testnet, we allow you to use our address as the sender = `0xE3deF8C6b7E357bf38eC701Ce631f78F2532987A`
+    ```
+    axelarcli q ethereum sendCommand 96c8dba428dbb0ce94ebd49eb342a13e8844630d28f80b8d8708324f0642cb3d 0xE3deF8C6b7E357bf38eC701Ce631f78F2532987A
+    ```
+    So use the above command, and just replace the `commandID` with your own.
 
-  e.g.,
+    If you see an `ERROR: eth bridge error: could not send transaction: authentication needed` please visit our discord channel and ask the team to unlock the Ethereum account used for sending out transactions.
 
-  ```
-  axelarcli tx bitcoin verifyTx "{\"OutPoint\":{\"Hash\":\"NxF/hGLGQZ6mTNyMWkYHPJ21E+2PMb1DV/beV7R9Gpk=\",\"Index\":1},\"Amount\":\"100000000\",\"BlockHash\":\"tPqsKekDOp5lW6QUl+YwlaD/3cmbQJwuUqgiNkqloQM=\",\"Address\":\"bcrt1qrnc097fuepeyrchganj4jzl2yuf5c0fg800uenr5h0d58emztxasusnk7p\",\"Confirmations\":\"21\"}"}" --from validator -y -b block
-  ```
-
-  Wait for verification to be confirmed (~10 Axelar blocks, ~50 secs).
-  Eventually, you'll see something like this in the node terminal:
-
-  `threshold of 2/3 has been met for bitcoinVerifyTx7d097730bbeba835e21dc0d953d4b1c3e42a6bf0da03e70f01a6bb0c1b71183c:1:`
-
-5. Trigger signing of the transfers to Ethereum
-
-  ```
-  axelarcli tx ethereum sign-pending-transfers --from validator -y -b block
-  -> returns commandID of signed tx
-  -> wait for sign protocol to complete (~10 blocks)
-  ```
-
-  Look for commandID and its value in the output: `"key": "commandID",
-    "value": "d5e993e407ff399cf2770a1d42bc2baf5308f46632fcbe209318acb09776599f"`
-
-6. Send the previous command to Ethereum
-  ```
-  axelarcli q ethereum sendCommand {commandID} {address of account that should send this tx}
-  ```
-  e.g., for the testnet, we allow you to use our address as the sender = `0xE3deF8C6b7E357bf38eC701Ce631f78F2532987A`
-  ```
-  axelarcli q ethereum sendCommand 96c8dba428dbb0ce94ebd49eb342a13e8844630d28f80b8d8708324f0642cb3d 0xE3deF8C6b7E357bf38eC701Ce631f78F2532987A
-  ```
-  So use the above command, and just replace the `commandID` with your own.
-
-  If you see an `ERROR: eth bridge error: could not send transaction: authentication needed` please visit our discord channel and ask the team to unlock the Ethereum account used for sending out transactions.
-
-You can now open Metamask, add the custom asset (`satoshi`) with contract address and see the minted Bitcoin tokens appear in it. We will use `0xF267edC09595683937d1560e512E9A79e09440FE` for the contract address on testnet, or ask Axelar on discord if you can't find it. See [here](https://axelar-static.s3.us-east-2.amazonaws.com/satoshi.png) for an example.
+    You can now open Metamask, add the custom asset (`satoshi`) with contract address and see the minted Bitcoin tokens appear in it. We will use `0xF267edC09595683937d1560e512E9A79e09440FE` for the contract address on testnet, or ask Axelar on discord if you can't find it. See [here](https://axelar-static.s3.us-east-2.amazonaws.com/satoshi.png) for an example.
 
 ### Burn ERC20 wrapped Bitcoin tokens and obtain native Satoshi
 
 To send wrapped Bitcoin back to Bitcoin, run the following commands:
 
 1. Create a deposit address on Ethereum
-
-  ```
-  axelarcli tx ethereum link bitcoin {bitcoin addr} satoshi --from validator -y -b block
-  -> returns deposit address
-  ```
-
-  e.g.,
-  ```
-  axelarcli tx ethereum link bitcoin tb1qg2z5jatp22zg7wyhpthhgwvn0un05mdwmqgjln satoshi --from validator -y -b block
-  ```
-
-  Look for the Ethereum deposit address. In the example below, it would be (`0x5CFE...`):
-
-  ```
-  "successfully linked {0x5CFEcE3b659e657E02e31d864ef0adE028a42a8E} and {tb1qq8wnre6rzctec9wycrl2dq00m3avravslahc8v}"
-  ```
-
-2. External: send wrapped tokens to the deposit address above (e.g. with Metamask**). You need to have some Ropsten testnet Ether on the address to send transactions, and you can use https://faucet.ropsten.be/ for that. Wait for 30 Ethereum block confirmations (5 - 30 minutes). You can track the number of block confirmations using https://ropsten.etherscan.io/ and the txID from the Activity tab of Metamask.
-
-**Note**: again, wait until you see at least 30 confirmations before proceeding to the next step.
-
+    ```
+    axelarcli tx ethereum link bitcoin {bitcoin addr} satoshi --from validator -y -b block
+    -> returns deposit address
+    ```
+    e.g.,
+    ```
+    axelarcli tx ethereum link bitcoin tb1qg2z5jatp22zg7wyhpthhgwvn0un05mdwmqgjln satoshi --from validator -y -b block
+    ```
+    Look for the Ethereum deposit address. In the example below, it would be (`0x5CFE...`):
+    ```
+    "successfully linked {0x5CFEcE3b659e657E02e31d864ef0adE028a42a8E} and {tb1qq8wnre6rzctec9wycrl2dq00m3avravslahc8v}"
+    ```
+2. External: send wrapped tokens to the deposit address above (e.g. with Metamask). You need to have some Ropsten testnet Ether on the address to send transactions, and you can use https://faucet.ropsten.be/ for that. Wait for 30 Ethereum block confirmations (5 - 30 minutes). You can track the number of block confirmations using https://ropsten.etherscan.io/ and the txID from the Activity tab of Metamask.
+    **Note**: again, wait until you see at least 30 confirmations before proceeding to the next step.
 3. Verify the Ethereum transaction
+    ```
+    axelarcli tx ethereum verify-erc20-deposit {txID} {amount} {deposit addr} --from validator -y -b block
+    -> wait for verification to be confirmed (~10 Axelar blocks)
+    ```
+    Here, amount should be specific in Satoshi. (For instance, 0.0001BTC = 10000 Satoshi)
 
-  ```
-  axelarcli tx ethereum verify-erc20-deposit {txID} {amount} {deposit addr} --from validator -y -b block
-  -> wait for verification to be confirmed (~10 Axelar blocks)
-  ```
-
-  Here, amount should be specific in Satoshi. (For instance, 0.0001BTC = 10000 Satoshi)
-  e.g.,
-
-  ```
-  axelarcli tx ethereum verify-erc20-deposit 0x01b00d7ed8f66d558e749daf377ca30ed45f747bbf64f2fd268a6d1ea84f916a 10000  0x5CFEcE3b659e657E02e31d864ef0adE028a42a8E --from validator -y -b block
-  -> wait for verification to be confirmed (~10 Axelar blocks, 1 minute)
-  ```
-
+    e.g.,
+    ```
+    axelarcli tx ethereum verify-erc20-deposit 0x01b00d7ed8f66d558e749daf377ca30ed45f747bbf64f2fd268a6d1ea84f916a 10000  0x5CFEcE3b659e657E02e31d864ef0adE028a42a8E --from validator -y -b block
+    -> wait for verification to be confirmed (~10 Axelar blocks, 1 minute)
+    ```
 4. Trigger signing of all pending transfers to Bitcoin
-
-  ```
-  axelarcli tx bitcoin sign-pending-transfers {tx fee} --from validator -b block -y
-  -> wait for sign protocol to complete (~10 Axelar blocks, 1 minute)
-  ```
-
- e.g.,
-
-  ```
-  axelarcli tx bitcoin sign-pending-transfers 0.0001btc --from validator -b block -y
-  ```
+    ```
+    axelarcli tx bitcoin sign-pending-transfers {tx fee} --from validator -b block -y
+    -> wait for sign protocol to complete (~10 Axelar blocks, 1 minute)
+    ```
+    e.g.,
+    ```
+    axelarcli tx bitcoin sign-pending-transfers 0.0001btc --from validator -b block -y
+    ```
 5. Submit the transfer to Bitcoin
+    ```
+    axelarcli q bitcoin send
+    -> returns tx ID
+    ```
+    You can monitor the status of your transfer using the bitcoin testnet explorer: https://blockstream.info/testnet/ .
 
-  ```
-  axelarcli q bitcoin send
-  -> returns tx ID
-  ```
-  You can monitor the status of your transfer using the bitcoin testnet explorer: https://blockstream.info/testnet/ .
-
-🛑 **IMPORTANT: Verify outpoints of previous withdrawal tx (repeat for each outpoint)**
-
+#### 🛑 **IMPORTANT: Verify outpoints of previous withdrawal tx (repeat for each outpoint)**
 Without this step, other users of the testnet will be unable to withdraw their wrapped tokens. Be a good citizen and verify the outpoints!
 
 1. Create verification json object for Axelar
-
-  ```
-  axelarcli q bitcoin txInfo {blockhash} {txID}:{voutIdx}
-  -> returns json of verification info for the given outpoint (copy the escaped string)
-  ```
-
-e.g.,
-
-  ```
-  axelarcli q bitcoin txInfo 4ac9dc50dc1b952cb1efca1e634216da2f5e3a12b4a4a802ce0f6b1271876bd2 da5b2e8037ce4b95f40ada01c6c2cd3ccb806d0a952906130eb9b806f7887590:1
-  ```
-
+    ```
+    axelarcli q bitcoin txInfo {blockhash} {txID}:{voutIdx}
+    -> returns json of verification info for the given outpoint (copy the escaped string)
+    ```
+    e.g.,
+    ```
+    axelarcli q bitcoin txInfo 4ac9dc50dc1b952cb1efca1e634216da2f5e3a12b4a4a802ce0f6b1271876bd2 da5b2e8037ce4b95f40ada01c6c2cd3ccb806d0a952906130eb9b806f7887590:1
+    ```
 2. Verify the Bitcoin outpoint
-
-  ```
-  axelarcli tx bitcoin verifyTx {"verification info" (output of previous cmd)} --from validator -y -b block
-  ```
-
-  e.g.,
-
-  ```
-  axelarcli tx bitcoin verifyTx "{\"OutPoint\":{\"Hash\":\"NxF/hGLGQZ6mTNyMWkYHPJ21E+2PMb1DV/beV7R9Gpk=\",\"Index\":1},\"Amount\":\"100000000\",\"BlockHash\":\"tPqsKekDOp5lW6QUl+YwlaD/3cmbQJwuUqgiNkqloQM=\",\"Address\":\"bcrt1qrnc097fuepeyrchganj4jzl2yuf5c0fg800uenr5h0d58emztxasusnk7p\",\"Confirmations\":\"21\"}" --from validator -y -b block
-  ```
+    ```
+    axelarcli tx bitcoin verifyTx {"verification info" (output of previous cmd)} --from validator -y -b block
+    ```
+    e.g.,
+    ```
+    axelarcli tx bitcoin verifyTx "{\"OutPoint\":{\"Hash\":\"NxF/hGLGQZ6mTNyMWkYHPJ21E+2PMb1DV/beV7R9Gpk=\",\"Index\":1},\"Amount\":\"100000000\",\"BlockHash\":\"tPqsKekDOp5lW6QUl+YwlaD/3cmbQJwuUqgiNkqloQM=\",\"Address\":\"bcrt1qrnc097fuepeyrchganj4jzl2yuf5c0fg800uenr5h0d58emztxasusnk7p\",\"Confirmations\":\"21\"}" --from validator -y -b block
+    ```

--- a/join/joinTestnet.sh
+++ b/join/joinTestnet.sh
@@ -6,10 +6,9 @@ AXELAR_CORE_VERSION=""
 TOFND_VERSION=""
 RESET_CHAIN=false
 ROOT_DIRECTORY=~/.axelar
-GIT_ROOT=$(git rev-parse --show-toplevel)
+GIT_ROOT="$(git rev-parse --show-toplevel)"
 
-for arg in "$@"
-do
+for arg in "$@"; do
   case $arg in
     --reset-chain)
     RESET_CHAIN=true
@@ -33,61 +32,58 @@ do
   esac
 done
 
-if [ -z "$AXELAR_CORE_VERSION" ]
-then
+if [ -z "$AXELAR_CORE_VERSION" ]; then
   echo "'--axelar-core vX.Y.Z' is required"
   exit 1
 fi
 
-if [ -z "$TOFND_VERSION" ]
-then
+if [ -z "$TOFND_VERSION" ]; then
   echo "'--tofnd vX.Y.Z' is required"
   exit 1
 fi
 
-if $RESET_CHAIN
-then
-  rm -rf $ROOT_DIRECTORY
+if $RESET_CHAIN; then
+  rm -rf "$ROOT_DIRECTORY"
 fi
 
-mkdir -p $ROOT_DIRECTORY
+mkdir -p "$ROOT_DIRECTORY"
 
-SHARED_DIRECTORY=$ROOT_DIRECTORY/shared
-mkdir -p $SHARED_DIRECTORY
+SHARED_DIRECTORY="${ROOT_DIRECTORY}/shared"
+mkdir -p "$SHARED_DIRECTORY"
 
-if [ ! -f $SHARED_DIRECTORY/genesis.json ]; then
-  curl https://axelar-testnet.s3.us-east-2.amazonaws.com/genesis.json -o $SHARED_DIRECTORY/genesis.json
+if [ ! -f "${SHARED_DIRECTORY}/genesis.json" ]; then
+  curl https://axelar-testnet.s3.us-east-2.amazonaws.com/genesis.json -o "${SHARED_DIRECTORY}/genesis.json"
 fi
 
-if [ ! -f $SHARED_DIRECTORY/peers.txt ]; then
-  curl https://axelar-testnet.s3.us-east-2.amazonaws.com/peers.txt -o $SHARED_DIRECTORY/peers.txt
+if [ ! -f "${SHARED_DIRECTORY}/peers.txt" ]; then
+  curl https://axelar-testnet.s3.us-east-2.amazonaws.com/peers.txt -o "${SHARED_DIRECTORY}/peers.txt"
 fi
 
-if [ ! -f $SHARED_DIRECTORY/config.toml ]; then
-  cp ${GIT_ROOT}/join/config.toml $SHARED_DIRECTORY/config.toml
+if [ ! -f "${SHARED_DIRECTORY}/config.toml" ]; then
+  cp "${GIT_ROOT}/join/config.toml" "${SHARED_DIRECTORY}/config.toml"
 fi
 
-if [ ! -f $SHARED_DIRECTORY/consumeGenesis.sh ]; then
-  cp ${GIT_ROOT}/join/consumeGenesis.sh $SHARED_DIRECTORY/consumeGenesis.sh
+if [ ! -f "${SHARED_DIRECTORY}/consumeGenesis.sh" ]; then
+  cp "${GIT_ROOT}/join/consumeGenesis.sh" "${SHARED_DIRECTORY}/consumeGenesis.sh"
 fi
 
-docker run \
-  --name tofnd \
-  -d \
+docker run       \
+  --name tofnd   \
+  -d             \
   -p 50051:50051 \
-  axelarnet/tofnd:$TOFND_VERSION
+  "axelarnet/tofnd:${TOFND_VERSION}"
 
-docker run \
-  --name axelar-core \
-  -p 1317:1317 \
-  -p 26656-26658:26656-26658 \
-  -p 26660:26660 \
-  --env TOFND_HOST=host.docker.internal \
-  --env START_REST=true \
-  --env PEERS_FILE=/root/shared/peers.txt \
-  --env INIT_SCRIPT=/root/shared/consumeGenesis.sh \
-  --env CONFIG_PATH=/root/shared/config.toml \
-  -v $ROOT_DIRECTORY/.axelard:/root/.axelard \
-  -v $ROOT_DIRECTORY/.axelarcli:/root/.axelarcli \
-  -v $SHARED_DIRECTORY:/root/shared \
-  axelarnet/axelar-core:$AXELAR_CORE_VERSION
+docker run                                           \
+  --name axelar-core                                 \
+  -p 1317:1317                                       \
+  -p 26656-26658:26656-26658                         \
+  -p 26660:26660                                     \
+  --env TOFND_HOST=host.docker.internal              \
+  --env START_REST=true                              \
+  --env PEERS_FILE=/root/shared/peers.txt            \
+  --env INIT_SCRIPT=/root/shared/consumeGenesis.sh   \
+  --env CONFIG_PATH=/root/shared/config.toml         \
+  -v "${ROOT_DIRECTORY}/.axelard:/root/.axelard"     \
+  -v "${ROOT_DIRECTORY}/.axelarcli:/root/.axelarcli" \
+  -v "${SHARED_DIRECTORY}:/root/shared"              \
+  "axelarnet/axelar-core:${AXELAR_CORE_VERSION}"


### PR DESCRIPTION
* Used 4 space indent on code blocks and text underneath numbered lists so it appears indented under each numbered item instead of looking like one left aligned runaway section.
* `--reset-chain` argument for `join/joinTestnet.sh` is dangerous due to lack of proper shell variable quoting and allows for accidentally deleting far more data than just the Axelar root directory under the right circumstances. Directories with spaces in them would have removed two levels of directories, e.g. `rm -rf /first/absolute/path second/relative/path` vs `rm -rf "/one/path with/spaces/"`.