### PR TITLE
doc: update some instructions

### DIFF
--- a/Exercises/exercise_2_btc_transfer_with_c2d2.md
+++ b/Exercises/exercise_2_btc_transfer_with_c2d2.md
@@ -55,13 +55,13 @@ List C2D2's accounts:
 c2d2cli eth-accounts
 ```
 
-Account 0 will be used to send transactions. Go to [https://faucet.ropsten.be/](https://faucet.ropsten.be/) to get some Ropsten ETH.
+Account 0 will be used to send transactions. Go to [https://faucet.ropsten.be/](https://faucet.ropsten.be/) to get some Ropsten ETH for the sender account.
 
 ### Mint ERC20 Bitcoin tokens on Ethereum
 1. Generate a Bitcoin deposit address. The Ethereum address you provide will be linked to the deposit address and receive the pegged bitcoin (Satoshi tokens) on the Ethereum testnet. 
 
     ```
-    c2d2cli deposit-btc ethereum [ethereum recipient address]
+    c2d2cli deposit-btc ethereum [your ethereum recipient address]
     ```
 
     You will see the deposit Bitcoin address printed in the terminal

--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ Mandatory flags:
 Optional flags:
 -r, --root          Local directory to store testnet data in (IMPORTANT: this directory is removed and recreated if --reset-chain is set)
 
---reset-chain       Delete local data to do a clean connect to the testnet
+--reset-chain       Delete local data to do a clean connect to the testnet (If you participated in an older version of the testnet)
 
 ```
-See https://hub.docker.com/repository/docker/axelarnet/axelar-core and https://hub.docker.com/repository/docker/axelarnet/tofnd for the latest available versions of the docker images.
+See TESTNET RELEASE.md for the latest available versions of the docker images.
 
 Once you join, at the terminal you should see blocks produced quickly. Wait for your node to catch up with the network before proceeding (When block production slows down to every 10 seconds). This can take a while.
 
@@ -76,10 +76,30 @@ If you find the log containing too much noise and hard to find useful informatio
 docker logs -f axelar-core 2>&1 | grep -e threshold -e num_txs -e proxies
 ```
 
+## Stop and restart testnet
+To leave the Axelar node CLI, type `exit`.
+To stop the node from syncing, press Control C, then 
+    ```
+    docker stop $(docker ps -a -q)
+    ```
+
+To restart the node, use two terminals to run
+    ```
+    docker start axelar-core -a
+    ```
+    ```
+    docker start tofnd -a
+    ```
+To enter Axelar node CLI again
+    ```
+    docker exec -it axelar-core sh
+    ```
+
+
 ## Ethereum account on testnet
 Axelar signs meta transactions for Ethereum, meaning that any Ethereum account can send transaction executing commands so long as the commands are signed by Axelar's key. In the exercises, all of the Ethereum-related transactions are sent from address `0xE3deF8C6b7E357bf38eC701Ce631f78F2532987A` on Ropsten testnet.
 
-### Generate a key on Axelar and get test tokens
+## Generate a key on Axelar and get test tokens
 1. On a new terminal window, enter Axelar node:
     ```
     docker exec -it axelar-core sh


### PR DESCRIPTION
General README updates such as restarting without synching, finding axelar core and tofnd versions from TESTNET RELEASE instead of docker.

Change latest c2d2 version to 0.1.5

Small c2d2 instruction changes

Please give feedback if you disagree :)