### PR TITLE
doc: instruction updates for exercise 3

### DIFF
--- a/BTC ETH NODE SETUP.md
+++ b/BTC ETH NODE SETUP.md
@@ -39,6 +39,7 @@ Set up a Bitcoin testnet node using `bitcoind` from `Bitcoin Core`.
   * Under `RPC API`, enable `RPC Server`.
   * Under `RPC API`, look for `RPC Auth`. Follow the link and provide a username and password. Write down the username and password as you will need it later. Copy the generated value and paste it back into the `RPC Auth` field.
   * Under `RPC API`, set `RPC Allow IP Address` as `0.0.0.0/0`.
+  * Under `RPC API`, set `Bind RPC Address` as the public IP address of the bitcoin node.
 
   Copy the contents of the generated `bitcoin.conf` file and paste it into the file you created in the last step.
 
@@ -152,4 +153,3 @@ Set up an Ethereum Ropsten testnet node using `Geth`.
   -H "Content-Type: application/json" \
   --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
   ```
-  

--- a/Exercises/exercise_3_join_validator.md
+++ b/Exercises/exercise_3_join_validator.md
@@ -233,7 +233,7 @@ Bitcoin and Ethereum node configuration will vary for different systems. Detaile
   ```
 
   Near the bottom of the JSON output, look for `Networks`, then `bridge`, `IPAddress`, and copy the address listed.
-  Next, ping the IP Address from inside `Axelar Core` to see if it works.
+  Next, ping the IP Address from inside `Axelar Core` to see if it works. Install the `ping` command if it does not exist already.
 
   ```
   docker exec axelar-core ping {your tofnd IP Address}

--- a/README.md
+++ b/README.md
@@ -142,18 +142,16 @@ Axelar signs meta transactions for Ethereum, meaning that any Ethereum account c
 
 ## Stop and restart testnet
 To leave the Axelar node CLI, type `exit`.
-To stop the node from syncing, press Control C, then 
+To stop the node, open a new CLI terminal and run
     ```
     docker stop $(docker ps -a -q)
     ```
+    ```
+    docker rm $(docker ps -a -q)
+    ```
 
-To restart the node, use two terminals to run
-    ```
-    docker start axelar-core -a
-    ```
-    ```
-    docker start tofnd -a
-    ```
+To restart the node, run the `join/joinTestnet.sh` script again, with the same `--axelar-core`, `--tofnd` (and optionally `--root`) parameters as before. Do NOT use the `--reset-chain` flag or your node will have to sync again from the beginning.
+
 To enter Axelar node CLI again
     ```
     docker exec -it axelar-core sh


### PR DESCRIPTION
Status: Ready to merge

Description:

Currently, some testnet validators are failing keygen because of timeout, because vald cannot connect to tofnd. This PR updates the ex3 instructions to include a series of checks which help to determine if valid/tofnd are configured and running properly, as well as steps to fix the connection issue.

Some other minor instruction updates are included

Testing: manual testing done by following the new instructions