### PR TITLE
chore(ex3): move exercise 3 to Admin folder

### DIFF
--- a/Admin/exercise_3_join_validator.md
+++ b/Admin/exercise_3_join_validator.md
@@ -11,6 +11,7 @@ Axelar Network is a work in progress. At no point in time should you transfer an
 
 ## Prerequisites
 - Complete all steps from `README.md`
+- Received permission from a testnet moderator or Axelar team member to run a validator
 
 ## Useful links
 - Extra commands to query Axelar Network state: https://github.com/axelarnetwork/axelarate-community/blob/main/EXTRA%20COMMANDS.md

--- a/Admin/exercise_3_join_validator.md
+++ b/Admin/exercise_3_join_validator.md
@@ -11,7 +11,7 @@ Axelar Network is a work in progress. At no point in time should you transfer an
 
 ## Prerequisites
 - Complete all steps from `README.md`
-- Received permission from a testnet moderator or Axelar team member to run a validator
+- While the network is in development, check in and receive an 'okay' from a testnet moderator or Axelar team member before starting
 
 ## Useful links
 - Extra commands to query Axelar Network state: https://github.com/axelarnetwork/axelarate-community/blob/main/EXTRA%20COMMANDS.md


### PR DESCRIPTION
Status: Ready to merge

Description: 
Currently, any testnet participant can read exercise 3 and attempt to become a validator. The goal is to only have approved people joining as validator for now.

Moving to Admin folder gives ex3 less visibility and this PR also adds team approval as a prerequisite before starting ex3