### PR TITLE
fix(tofnd): point to new tofnd local path root

### DIFF
--- a/join/joinTestnet.sh
+++ b/join/joinTestnet.sh
@@ -78,7 +78,7 @@ docker run       \
   --name tofnd   \
   -d             \
   -p 50051:50051 \
-  -v "${ROOT_DIRECTORY}:/root/.kvstore" \
+  -v "${ROOT_DIRECTORY}:/root/.tofnd" \
   "axelarnet/tofnd:${TOFND_VERSION}"
 
 docker run                                           \


### PR DESCRIPTION
As of [this tofnd commit](https://github.com/axelarnetwork/tofnd/commit/9bd8c11c1390af8178aae976b76601bf71ed0c96) tofnd now stores all local data in `/.tofnd`.  This PR reflects this change: `.kvstore -> .tofnd`.  Need to synchronize this PR with the next version of testnet.