### PR TITLE
Update setup.md for correct path to release

### DIFF
--- a/documentation/docs/setup.md
+++ b/documentation/docs/setup.md
@@ -70,8 +70,8 @@ See [Testnet Release](/testnet-releases) for the latest available versions of th
 
 You can get the latest version and save it to variables:
 ```bash
-TOFND_VERSION=$(curl -s https://raw.githubusercontent.com/axelarnetwork/axelarate-community/main/TESTNET%20RELEASE.md | grep tofnd | cut -d \` -f 4)
-CORE_VERSION=$(curl -s https://raw.githubusercontent.com/axelarnetwork/axelarate-community/main/TESTNET%20RELEASE.md | grep axelar-core | cut -d \` -f 4)
+TOFND_VERSION=$(curl -s https://raw.githubusercontent.com/axelarnetwork/axelarate-community/main/documentation/docs/testnet-releases.md | grep tofnd | cut -d \` -f 4)
+CORE_VERSION=$(curl -s https://raw.githubusercontent.com/axelarnetwork/axelarate-community/main/documentation/docs/testnet-releases.md  | grep axelar-core | cut -d \` -f 4)
 echo ${TOFND_VERSION} ${CORE_VERSION}
 ```
 


### PR DESCRIPTION
tested locally:
```
$ TOFND_VERSION=$(curl -s https://raw.githubusercontent.com/axelarnetwork/axelarate-community/main/documentation/docs/testnet-releases.md | grep tofnd | cut -d \` -f 4)
$ CORE_VERSION=$(curl -s https://raw.githubusercontent.com/axelarnetwork/axelarate-community/main/documentation/docs/testnet-releases.md  | grep axelar-core | cut -d \` -f 4) 
$ echo ${TOFND_VERSION} ${CORE_VERSION}
v0.4.0 v0.5.2
```