### PR TITLE
chore: add script to join testnet with binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ yarn.lock
 .vercel
 /package-lock.json
 /.idea/
+.tofnd

--- a/documentation/Admin/validator_backup.md
+++ b/documentation/Admin/validator_backup.md
@@ -14,11 +14,11 @@ For recover instructions, please see [recover](./validator_recover.md).
 The Tendermint validator key is created when a node is launched for the first time.
 It can be found within the node's container at `/root/.axelar/config/priv_validator_key.json` (or on the host at `$HOME/.axelar_testnet/.core/config/priv_validator_key.json`).
 
-#### Key backup 
+#### Key backup
 
 The content of the `priv_validator_key` file should look something like:
 
-```
+```bash
 {
   "address": "98AF6E5D52BBB62BE6717DE8C55F16F5C013D7BE",
   "pub_key": {
@@ -39,23 +39,23 @@ The content of the `priv_validator_key` file should look something like:
 The Axelar mnemonics are created when an node/validator is launched for the first time and subsequently outputed to the terminal.
 The output looks something like:
 
-```
+```bash
 **Important** write this mnemonic phrase in a safe place.
 It is the only way to recover your account if you ever forget your password.
 
 range elder logic subject never utility dutch novel sail vacuum model robust coin upper egg trophy track chimney garlic random fury laundry kiss sight
 ```
 
-#### Mnemonic backup 
+#### Mnemonic backup
 
-There should be one mnemonic for the Axelar validator key and another for the Axelar proxy key. 
+There should be one mnemonic for the Axelar validator key and another for the Axelar proxy key.
 The former should be displayed after running `join/joinTestnet.sh` with a clean slate, while the latter should be displayed by `join/launchValidator.sh`.
 
 **Attention:** Be sure to store this mnemonic at a safe, offline place.
 
 ### Tofnd mnemonic
 
-Tofnd needs to be provided with a mnemonic the first time it operates. From this mnemonic, a private key is derived and stored in tofnd's internal database. The private key is used to encrypt and decrypt the recovery information of the user. 
+Tofnd needs to be provided with a mnemonic the first time it operates. From this mnemonic, a private key is derived and stored in tofnd's internal database. The private key is used to encrypt and decrypt the recovery information of the user.
 
 By default, a mnemonic is created when tofnd is launched for the first time. Users can use this mnenonic to recover their information in case of data loss. Once a private key is created and stored at tofnd's internal database, the mnemonic file is no longer needed.
 
@@ -64,7 +64,7 @@ If you are running tofnd in a **containerized environment**, the mnemonic can be
 If you are running tofnd as a **binary**, the mnemonic can be found under the directory from which you ran the executable, at `$TOFND_PATH/.tofnd/export`.
 
 The mnemonic file should look something like:
-```
+```bash
 purchase arrow sword basic gasp category hundred town layer snow mother roast digital fragile repeat monitor wrong combine awful nature damage rib skull chalk
 ```
 

--- a/documentation/Admin/validator_recovery.md
+++ b/documentation/Admin/validator_recovery.md
@@ -18,13 +18,19 @@ In order to restore the Tendermint key and/or the Axelar validator key used by a
 ```
 ./join/joinTestnet.sh --tendermint-key /path/to/tendermint/key/ --validator-mnemonic /path/to/axelar/mnemonic/
 ```
+
+If you are using the binary, you can add the flags to the binary script, similar to joinTestnet.sh, for example:
+```bash
+./join/join-testnet-with-binaries.sh --tendermint-key /path/to/tendermint/key/ --validator-mnemonic /path/to/axelar/mnemonic/
+```
+
 ### Recovery data
 
 The recovery data is stored on chain, and enables a validator to recover key shares it created.
 To obtain the recovery data for those key shares, you need to find out the corresponding key IDs first.
 To query the blockchain for these key IDs - and assuming that the Axelar validator account has already been restored - attach a terminal to the node's container and perform the command:
 
-```
+```bash
 ~/scripts # axelard q tss key-shares-validator $(axelard keys show validator --bech val -a)
 - key_chain: Bitcoin
   key_id: btc-master
@@ -45,7 +51,7 @@ To query the blockchain for these key IDs - and assuming that the Axelar validat
 In this example, the validator participated in generating the keys with ID `btc-master` and `btc-secondary`.
 With the help of the key IDs, you can now retrieve the recovery data for the keys:
 
-```
+```bash
 axelard q tss recover $(axelard keys show validator --bech val -a) btc-master btc-secondary --output json > recovery.json
 ```
 
@@ -56,7 +62,7 @@ This file will contain the data necessary to perform share recovery.
 
 In order to restore the Axelar proxy key used by the Vald process, you can use the `--validator-mnemonic` flag with `join/launchValidator.sh` as follows:
 
-```
+```bash
 ./join/joinTestnet.sh --proxy-mnemonic /path/to/axelar/mnemonic/
 ```
 
@@ -64,20 +70,20 @@ In order to restore the Axelar proxy key used by the Vald process, you can use t
 
 If you want to reset your tofnd (e.g. on a new machine, after unexpected data loss, etc), you will have to recover your tofnd state. Tofnd's state consists of the following:
 1. **your private key**: Internal tofnd key used to encrypt your recovery data. This private key is derived from a mnemonic that is generated automatically when tofnd is executed for the first time on your machine. You should have stored this mneminic safely, since it is the only passphrase that can be used to recover your key shares.
-2. **your key shares**: Data that is generated when you participate into a keygen and is used to perform sign. 
+2. **your key shares**: Data that is generated when you participate into a keygen and is used to perform sign.
 
 Each time you participated in a keygen, your key shares were encrypted and stored on the blockchain. This means that you can easily fetch your shares, but you must have your private key (i.e. launch tofnd with your mnemonic) to successfully decrypt them.
 
 #### Running tofnd in a containerized environment
 
-In order to restore tofnd's private key and your key shares, you can use `join/launchValidator.sh` with the `--tofnd-mnemonic` and `--recovery-info` flags with as follows: 
+In order to restore tofnd's private key and your key shares, you can use `join/launchValidator.sh` with the `--tofnd-mnemonic` and `--recovery-info` flags with as follows:
 
-```
+```bash
 ./join/joinTestnet.sh --tofnd-mnemonic <mnemonic file> ---recovery-info <recover json file>
 ```
 
-1. `<mnemonic file>`: A file that contains your mnemonic passphrase  
-2. `<recover json file>`: The recovery information in json format you receive by executing 
+1. `<mnemonic file>`: A file that contains your mnemonic passphrase
+2. `<recover json file>`: The recovery information in json format you receive by executing
     ```
     axelard q tss recover $(axelard keys show validator --bech val -a) btc-master btc-secondary --output json > recovery.json
     ```
@@ -89,10 +95,10 @@ If you are running a tofnd binary, follow the steps below:
 1. Create your recovery json file from your vald process (see section [Recovery Data](#Recovery_Data)
 2. Copy the json recovery file to `~/.axelar_testnet/.vald/recovery.json`
 3. Navigate to the directory of your tofnd binary.
-4. Create a folder under the name `.tofnd/`. 
+4. Create a folder under the name `.tofnd/`.
 5. Create a file `.tofnd/import` that contains your mnemonic passphrase.
 6. Execute tofnd in *import* mode:
-    ```
+    ```bash
     ./tofnd -m import
     ```
     The output should be similar to the following:
@@ -103,14 +109,14 @@ If you are running a tofnd binary, follow the steps below:
     kv_manager cannot open existing db [.tofnd/kvstore/shares]. creating new db
     Mnemonic successfully added in kv store
     ```
-7. Restart vald 
+7. Restart vald
 8. You should now see the following in your tofnd logs:
-    ```
+    ```bash
     Recovering keypair for party X ...
     Finished recovering keypair for party X
     Recovery completed successfully!
     ```
 
-Tofnd has now re-created the private key that is derived from your mnemonic into tofnd's internal database, fetched your shares from the blockchain, decrypted them using your private key, and finally stored them at its internal tofnd database. Once recoverred, can remove your mnemonic file you used, as it is no longer needed. 
+Tofnd has now re-created the private key that is derived from your mnemonic into tofnd's internal database, fetched your shares from the blockchain, decrypted them using your private key, and finally stored them at its internal tofnd database. Once recoverred, can remove your mnemonic file you used, as it is no longer needed.
 
 **Attention**: Remember to still keep your mnemonic stored at an offline, secure place for future recoveries.

--- a/join/join-testnet-with-binaries.sh
+++ b/join/join-testnet-with-binaries.sh
@@ -120,7 +120,6 @@ export AXELARD_CHAIN_ID=${AXELARD_CHAIN_ID:-"axelar"}
 
 echo "Node moniker: $NODE_MONIKER"
 echo "Axelar Chain ID: $AXELARD_CHAIN_ID"
-set -x
 ACCOUNTS=$($AXELARD keys list -n --home $CORE_DIRECTORY)
 for ACCOUNT in $ACCOUNTS; do
     if [ "$ACCOUNT" == "validator" ]; then
@@ -151,7 +150,6 @@ export START_REST=true
 "$AXELARD" start --home $CORE_DIRECTORY > "$LOGS_DIRECTORY/axelard.log" 2>&1 &
 
 VALIDATOR=$("$AXELARD" keys show validator -a --bech val --home $CORE_DIRECTORY)
-set +x
 echo
 echo "Axelar node running."
 echo

--- a/join/join-testnet-with-binaries.sh
+++ b/join/join-testnet-with-binaries.sh
@@ -146,6 +146,8 @@ if [ ! -f "$CONFIG_DIRECTORY/genesis.json" ]; then
   fi
 fi
 
+export START_REST=true
+
 "$AXELARD" start --home $CORE_DIRECTORY > "$LOGS_DIRECTORY/axelard.log" 2>&1 &
 
 VALIDATOR=$("$AXELARD" keys show validator -a --bech val --home $CORE_DIRECTORY)

--- a/join/join-testnet-with-binaries.sh
+++ b/join/join-testnet-with-binaries.sh
@@ -79,11 +79,11 @@ mkdir -p "$BIN_DIRECTORY"
 LOGS_DIRECTORY="${ROOT_DIRECTORY}/logs"
 mkdir -p "$LOGS_DIRECTORY"
 
-CONFIG_DIRECTORY="${ROOT_DIRECTORY}/config"
-mkdir -p "$CONFIG_DIRECTORY"
-
 CORE_DIRECTORY="${ROOT_DIRECTORY}/.core"
 mkdir -p "$CORE_DIRECTORY"
+
+CONFIG_DIRECTORY="${CORE_DIRECTORY}/config"
+mkdir -p "$CONFIG_DIRECTORY"
 
 AXELARD_BINARY="axelard-${OS}-${ARCH}-${AXELAR_CORE_VERSION}"
 if [ ! -f "${AXELARD}" ]; then
@@ -121,7 +121,7 @@ export AXELARD_CHAIN_ID=${AXELARD_CHAIN_ID:-"axelar"}
 echo "Node moniker: $NODE_MONIKER"
 echo "Axelar Chain ID: $AXELARD_CHAIN_ID"
 set -x
-ACCOUNTS=$($AXELARD keys list -n --home $ROOT_DIRECTORY)
+ACCOUNTS=$($AXELARD keys list -n --home $CORE_DIRECTORY)
 for ACCOUNT in $ACCOUNTS; do
     if [ "$ACCOUNT" == "validator" ]; then
         HAS_VALIDATOR=true
@@ -131,24 +131,24 @@ done
 touch "$ROOT_DIRECTORY/validator.txt"
 if [ -z "$HAS_VALIDATOR" ]; then
   if [ -f "$AXELAR_MNEMONIC_PATH" ]; then
-    "$AXELARD" keys add validator --recover --home $ROOT_DIRECTORY <"$AXELAR_MNEMONIC_PATH"
+    "$AXELARD" keys add validator --recover --home $CORE_DIRECTORY <"$AXELAR_MNEMONIC_PATH"
   else
-    "$AXELARD" keys add validator --home $ROOT_DIRECTORY > "$ROOT_DIRECTORY/validator.txt" 2>&1
+    "$AXELARD" keys add validator --home $CORE_DIRECTORY > "$ROOT_DIRECTORY/validator.txt" 2>&1
   fi
 fi
 
-"$AXELARD" keys show validator -a --bech val --home $ROOT_DIRECTORY > "$ROOT_DIRECTORY/validator.bech"
+"$AXELARD" keys show validator -a --bech val --home $CORE_DIRECTORY > "$ROOT_DIRECTORY/validator.bech"
 
 if [ ! -f "$CONFIG_DIRECTORY/genesis.json" ]; then
-  "$AXELARD" init "$NODE_MONIKER" --chain-id "$AXELARD_CHAIN_ID" --home $ROOT_DIRECTORY
+  "$AXELARD" init "$NODE_MONIKER" --chain-id "$AXELARD_CHAIN_ID" --home $CORE_DIRECTORY
   if [ -f "$TENDERMINT_KEY_PATH" ]; then
     cp -f "$TENDERMINT_KEY_PATH" "$CONFIG_DIRECTORY/priv_validator_key.json"
   fi
 fi
 
-"$AXELARD" start --home $ROOT_DIRECTORY > "$LOGS_DIRECTORY/axelard.log" 2>&1 &
+"$AXELARD" start --home $CORE_DIRECTORY > "$LOGS_DIRECTORY/axelard.log" 2>&1 &
 
-VALIDATOR=$("$AXELARD" keys show validator -a --bech val --home $ROOT_DIRECTORY)
+VALIDATOR=$("$AXELARD" keys show validator -a --bech val --home $CORE_DIRECTORY)
 set +x
 echo
 echo "Axelar node running."

--- a/join/join-testnet-with-binaries.sh
+++ b/join/join-testnet-with-binaries.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+set -e
+
+AXELAR_CORE_VERSION=""
+TOFND_VERSION=""
+RESET_CHAIN=false
+ROOT_DIRECTORY=~/.axelar_testnet
+GIT_ROOT="$(git rev-parse --show-toplevel)"
+
+for arg in "$@"; do
+  case $arg in
+    --reset-chain)
+    RESET_CHAIN=true
+    shift
+    ;;
+    -r|--root)
+    ROOT_DIRECTORY="$2"
+    shift
+    ;;
+    --axelar-core)
+    AXELAR_CORE_VERSION="$2"
+    shift
+    ;;
+    --tofnd)
+    TOFND_VERSION="$2"
+    shift
+    ;;
+    *)
+    shift
+    ;;
+  esac
+done
+
+if [ -z "$AXELAR_CORE_VERSION" ]; then
+  echo "'--axelar-core vX.Y.Z' is required"
+  exit 1
+fi
+
+if [ -z "$TOFND_VERSION" ]; then
+  echo "'--tofnd vX.Y.Z' is required"
+  exit 1
+fi
+
+if $RESET_CHAIN; then
+  rm -rf "$ROOT_DIRECTORY"
+fi
+
+mkdir -p "$ROOT_DIRECTORY"
+
+SHARED_DIRECTORY="${ROOT_DIRECTORY}/shared"
+mkdir -p "$SHARED_DIRECTORY"
+
+TOFND_DIRECTORY="${ROOT_DIRECTORY}/.tofnd"
+mkdir -p "$TOFND_DIRECTORY"
+
+if [ ! -f "${SHARED_DIRECTORY}/genesis.json" ]; then
+  curl https://axelar-testnet.s3.us-east-2.amazonaws.com/genesis.json -o "${SHARED_DIRECTORY}/genesis.json"
+fi
+
+if [ ! -f "${SHARED_DIRECTORY}/peers.txt" ]; then
+  curl https://axelar-testnet.s3.us-east-2.amazonaws.com/peers.txt -o "${SHARED_DIRECTORY}/peers.txt"
+fi
+
+if [ ! -f "${SHARED_DIRECTORY}/config.toml" ]; then
+  cp "${GIT_ROOT}/join/config.toml" "${SHARED_DIRECTORY}/config.toml"
+fi
+
+if [ ! -f "${SHARED_DIRECTORY}/app.toml" ]; then
+  cp "${GIT_ROOT}/join/app.toml" "${SHARED_DIRECTORY}/app.toml"
+fi
+
+if [ ! -f "${SHARED_DIRECTORY}/consumeGenesis.sh" ]; then
+  cp "${GIT_ROOT}/join/consumeGenesis.sh" "${SHARED_DIRECTORY}/consumeGenesis.sh"
+fi
+
+# docker run       \
+#   --name tofnd   \
+#   -d             \
+#   -p 50051:50051 \
+#   -v "${ROOT_DIRECTORY}:/root/.tofnd" \
+#   "axelarnet/tofnd:${TOFND_VERSION}"
+
+# docker run                                           \
+#   --name axelar-core                                 \
+#   -p 1317:1317                                       \
+#   -p 26656-26658:26656-26658                         \
+#   -p 26660:26660                                     \
+#   --env TOFND_HOST=host.docker.internal              \
+#   --env START_REST=true                              \
+#   --env PEERS_FILE=/root/shared/peers.txt            \
+#   --env INIT_SCRIPT=/root/shared/consumeGenesis.sh   \
+#   --env CONFIG_PATH=/root/shared/                    \
+#   -v "${ROOT_DIRECTORY}/.axelar:/root/.axelar"     \
+#   -v "${SHARED_DIRECTORY}:/root/shared"              \
+#   "axelarnet/axelar-core:${AXELAR_CORE_VERSION}"

--- a/join/launch-validator-with-binaries.sh
+++ b/join/launch-validator-with-binaries.sh
@@ -88,6 +88,8 @@ fi
 VALD_DIRECTORY="$ROOT_DIRECTORY/.vald"
 mkdir -p "$VALD_DIRECTORY"
 
+CORE_DIRECTORY="${ROOT_DIRECTORY}/.core"
+
 TOFND_DIRECTORY="$HOME/.tofnd"
 mkdir -p "$TOFND_DIRECTORY"
 
@@ -119,14 +121,15 @@ fi
 
 $AXELARD keys show broadcaster -a --home $VALD_DIRECTORY > "$ROOT_DIRECTORY/broadcaster.bech"
 
-VALIDATOR_ADDR=$($AXELARD keys show validator -a --bech val --home $ROOT_DIRECTORY)
+VALIDATOR_ADDR=$($AXELARD keys show validator -a --bech val --home $CORE_DIRECTORY)
 if [ -z "$VALIDATOR_ADDR" ]; then
   until [ -f "$ROOT_DIRECTORY/validator.bech" ] ; do
     echo "Waiting for validator address to be accessible in $shared_dir"
     sleep 5
   done
+  export VALIDATOR_ADDR=$(cat "$ROOT_DIRECTORY/validator.bech")
 fi
-export VALIDATOR_ADDR=$(cat "$ROOT_DIRECTORY/validator.bech")
+
 
 "$TOFND" -m "$MNEMONIC_CMD" > "$LOGS_DIRECTORY/tofnd.log" 2>&1 &
 
@@ -149,8 +152,8 @@ set -x
     ${VALIDATOR_HOST:+--node "$VALIDATOR_HOST"} \
     --home "${VALD_DIRECTORY}" \
     --validator-addr "${VALIDATOR_ADDR}" \
-    "$RECOVERY"
-    # > "$LOGS_DIRECTORY/vald.log" 2>&1 &
+    "$RECOVERY" > "$LOGS_DIRECTORY/vald.log" 2>&1 &
+
 set +x
 
 BROADCASTER=$($AXELARD keys show broadcaster -a --home $VALD_DIRECTORY)

--- a/join/launch-validator-with-binaries.sh
+++ b/join/launch-validator-with-binaries.sh
@@ -153,7 +153,6 @@ set -x
     --home "${VALD_DIRECTORY}" \
     --validator-addr "${VALIDATOR_ADDR}" \
     "$RECOVERY" > "$LOGS_DIRECTORY/vald.log" 2>&1 &
-
 set +x
 
 BROADCASTER=$($AXELARD keys show broadcaster -a --home $VALD_DIRECTORY)

--- a/join/launch-validator-with-binaries.sh
+++ b/join/launch-validator-with-binaries.sh
@@ -15,7 +15,6 @@ ARCH="$(uname -m)"
 
 
 set -e
-set -x
 for arg in "$@"; do
   case $arg in
     --proxy-mnemonic)
@@ -173,14 +172,12 @@ fi
 
 export KEYRING_BACKEND=test
 
-set -x
 "$AXELARD" vald-start ${TOFND_HOST:+--tofnd-host "$TOFND_HOST"} \
     ${VALIDATOR_HOST:+--node "$VALIDATOR_HOST"} \
     --home "${VALD_DIRECTORY}" \
     --validator-addr "${VALIDATOR_ADDR}" \
     --log_level debug \
     "$RECOVERY" > "$LOGS_DIRECTORY/vald.log" 2>&1 &
-set +x
 
 BROADCASTER=$($AXELARD keys show broadcaster -a --home $VALD_DIRECTORY)
 

--- a/join/launch-validator-with-binaries.sh
+++ b/join/launch-validator-with-binaries.sh
@@ -1,0 +1,175 @@
+#!/bin/sh
+
+TOFND_MNEMONIC_PATH=""
+AXELAR_MNEMONIC_PATH=""
+RECOVERY_INFO_PATH=""
+AXELAR_CORE_VERSION="$(curl -s https://raw.githubusercontent.com/axelarnetwork/axelarate-community/main/documentation/docs/testnet-releases.md  | grep axelar-core | cut -d \` -f 4)"
+TOFND_VERSION="$(curl -s https://raw.githubusercontent.com/axelarnetwork/axelarate-community/main/documentation/docs/testnet-releases.md  | grep tofnd | cut -d \` -f 4)"
+ROOT_DIRECTORY="$HOME/.axelar_testnet"
+GIT_ROOT="$(git rev-parse --show-toplevel)"
+BIN_DIRECTORY="$ROOT_DIRECTORY/bin"
+AXELARD="$BIN_DIRECTORY/axelard"
+AXELARD_CMD="$AXELARD"
+TOFND="$BIN_DIRECTORY/tofnd"
+TOFND_CMD="$TOFND"
+OS="$(uname | awk '{print tolower($0)}')"
+ARCH="$(uname -m)"
+
+
+set -e
+
+for arg in "$@"; do
+  case $arg in
+    --proxy-mnemonic)
+    AXELAR_MNEMONIC_PATH="$2"
+    shift
+    ;;
+    --tofnd-mnemonic)
+    TOFND_MNEMONIC_PATH="$2"
+    shift
+    ;;
+    --recovery-info)
+    RECOVERY_INFO_PATH="$2"
+    shift
+    ;;
+    -r|--root)
+    ROOT_DIRECTORY="$2"
+    shift
+    ;;
+    --axelar-core)
+    AXELAR_CORE_VERSION="$2"
+    shift
+    ;;
+    --tofnd)
+    TOFND_VERSION="$2"
+    shift
+    ;;
+    *)
+    shift
+    ;;
+  esac
+done
+
+if [ -z "$AXELAR_CORE_VERSION" ]; then
+  echo "'--axelar-core vX.Y.Z' is required"
+  exit 1
+fi
+
+if [ -z "$TOFND_VERSION" ]; then
+  echo "'--tofnd vX.Y.Z' is required"
+  exit 1
+fi
+
+echo "TOFND Version: ${TOFND_VERSION}"
+echo "Axelar Core Version: ${AXELAR_CORE_VERSION}"
+echo "OS: ${OS}"
+echo "Architecture: ${ARCH}"
+
+if [ ! -d "$ROOT_DIRECTORY" ]; then
+  echo "Root directory does not exist"
+  exit 1
+fi
+echo "Root Directory: ${ROOT_DIRECTORY}"
+LOGS_DIRECTORY="${ROOT_DIRECTORY}/logs"
+mkdir -p "$LOGS_DIRECTORY"
+echo "Logs Directory: $LOGS_DIRECTORY"
+
+TOFND_BINARY="tofnd-${OS}-${ARCH}-${TOFND_VERSION}"
+if [ ! -f "${TOFND}" ]; then
+  echo "Downloading tofnd binary $TOFND_BINARY"
+  curl -s https://axelar-releases.s3.us-east-2.amazonaws.com/tofnd/${TOFND_VERSION}/${TOFND_BINARY} -o "${TOFND}" && chmod +x "${TOFND}"
+fi
+
+
+NODE_UP="$(ps aux | grep '[a]xelard start --home')"
+if [ -z "$NODE_UP" ]; then
+  echo "No node running"
+  exit 1
+fi
+
+VALD_DIRECTORY="$HOME/.vald"
+mkdir -p "$VALD_DIRECTORY"
+
+TOFND_DIRECTORY="$HOME/.tofnd"
+mkdir -p "$TOFND_DIRECTORY"
+
+if [ -f "$RECOVERY_INFO_PATH" ]; then
+  cp -f "$RECOVERY_INFO_PATH" "$VALD_DIRECTORY/recovery.json"
+fi
+
+MNEMONIC_CMD=create
+if [ -f "$TOFND_MNEMONIC_PATH" ]; then
+  cp -f "$TOFND_MNEMONIC_PATH" "$TOFND_MNEMONIC_PATH/import"
+  MNEMONIC_CMD=import
+fi
+
+ACCOUNTS=$($AXELARD_CMD keys list -n --home $ROOT_DIRECTORY)
+for ACCOUNT in $ACCOUNTS; do
+  if [ "$ACCOUNT" == "broadcaster" ]; then
+    HAS_BROADCASTER=true
+  fi
+done
+
+touch "$ROOT_DIRECTORY/broadcaster.txt"
+if [ -z "$HAS_BROADCASTER" ]; then
+  if [ -f "$AXELAR_MNEMONIC_PATH" ]; then
+    $AXELARD_CMD keys add broadcaster --recover --home $ROOT_DIRECTORY < "$AXELAR_MNEMONIC_PATH"
+  else
+    $AXELARD_CMD keys add broadcaster --home $ROOT_DIRECTORY > "$ROOT_DIRECTORY/broadcaster.txt" 2>&1
+  fi
+fi
+
+$AXELARD_CMD keys show broadcaster -a --home $ROOT_DIRECTORY > "$ROOT_DIRECTORY/broadcaster.bech"
+
+VALIDATOR_ADDR=$($AXELARD_CMD keys show validator -a --bech val --home $ROOT_DIRECTORY)
+if [ -z "$VALIDATOR_ADDR" ]; then
+  until [ -f "$ROOT_DIRECTORY/validator.bech" ] ; do
+    echo "Waiting for validator address to be accessible in $shared_dir"
+    sleep 5
+  done
+fi
+export VALIDATOR_ADDR=$(cat "$ROOT_DIRECTORY/validator.bech")
+
+"$BIN_DIRECTORY"/tofnd -m "$MNEMONIC_CMD" > "$LOGS_DIRECTORY/tofnd.log" 2>&1 &
+
+sleep 5
+
+export VALIDATOR_HOST=http://localhost:26657
+export SLEEP_TIME=2
+export TOFND_HOST=localhost
+export RECOVERY_FILE="$ROOT_DIRECTORY"/recovery.json
+export AXELAR_MNEMONIC_PATH=$AXELAR_MNEMONIC_PATH
+
+sleep "$SLEEP_TIME"
+RECOVERY=""
+if [ -n "$RECOVERY_FILE" ] && [ -f "$RECOVERY_FILE" ]; then
+    RECOVERY="--tofnd-recovery=$RECOVERY_FILE"
+fi
+
+set -x
+"$AXELARD_CMD" vald-start ${TOFND_HOST:+--tofnd-host "$TOFND_HOST"} \
+    ${VALIDATOR_HOST:+--node "$VALIDATOR_HOST"} \
+    --home "${ROOT_DIRECTORY}" \
+    --validator-addr "${VALIDATOR_ADDR}" \
+    "$RECOVERY" > "$LOGS_DIRECTORY/vald.log" 2>&1 &
+set +x
+
+BROADCASTER=$($AXELARD_CMD keys show broadcaster -a --home $ROOT_DIRECTORY)
+
+echo
+echo "Tofnd & Vald running."
+echo
+echo "Proxy address: $BROADCASTER"
+echo
+echo "To become a validator get some uaxl tokens from the faucet and stake them"
+echo
+
+cat "$ROOT_DIRECTORY/broadcaster.txt"
+rm -rf "$ROOT_DIRECTORY/broadcaster.txt"
+echo "Do not forget to also backup the tofnd mnemonic (${TOFND_DIRECTORY}/export)"
+echo
+echo "To follow tofnd execution, run 'tail -f ${LOGS_DIRECTORY}/tofnd.logs'"
+echo "To follow vald execution, run 'tail -f ${LOGS_DIRECTORY}/vald.logs'"
+echo "To stop tofnd, run 'killall tofnd'"
+echo "To stop vald, run 'killall vald'"
+echo


### PR DESCRIPTION
The tofnd binary does not allow changing the name of the home directory. so the home directory ends up being ~/.tofnd and ./.tofnd. This needs to be fixed in the future.

The idea is that this brings us to parity with the joinTestnet.sh and launchValidator.sh scripts.


Will need help from @jcs47 to test this properly.