### PR TITLE
fix(script): replace OS not ARCH variable

### DIFF
--- a/join/join-testnet-with-binaries.sh
+++ b/join/join-testnet-with-binaries.sh
@@ -90,7 +90,7 @@ mkdir -p "$CORE_DIRECTORY"
 CONFIG_DIRECTORY="${CORE_DIRECTORY}/config"
 mkdir -p "$CONFIG_DIRECTORY"
 
-AXELARD_BINARY="axelard1-${OS}-${ARCH}-${AXELAR_CORE_VERSION}"
+AXELARD_BINARY="axelard-${OS}-${ARCH}-${AXELAR_CORE_VERSION}"
 if [ ! -f "${AXELARD}" ]; then
   echo "Downloading axelard binary $AXELARD_BINARY"
   curl -s --fail https://axelar-releases.s3.us-east-2.amazonaws.com/axelard/${AXELAR_CORE_VERSION}/${AXELARD_BINARY} -o "${AXELARD}" && chmod +x "${AXELARD}"

--- a/join/join-testnet-with-binaries.sh
+++ b/join/join-testnet-with-binaries.sh
@@ -90,20 +90,20 @@ mkdir -p "$CORE_DIRECTORY"
 CONFIG_DIRECTORY="${CORE_DIRECTORY}/config"
 mkdir -p "$CONFIG_DIRECTORY"
 
-AXELARD_BINARY="axelard-${OS}-${ARCH}-${AXELAR_CORE_VERSION}"
+AXELARD_BINARY="axelard1-${OS}-${ARCH}-${AXELAR_CORE_VERSION}"
 if [ ! -f "${AXELARD}" ]; then
   echo "Downloading axelard binary $AXELARD_BINARY"
-  curl -s https://axelar-releases.s3.us-east-2.amazonaws.com/axelard/${AXELAR_CORE_VERSION}/${AXELARD_BINARY} -o "${AXELARD}" && chmod +x "${AXELARD}"
+  curl -s --fail https://axelar-releases.s3.us-east-2.amazonaws.com/axelard/${AXELAR_CORE_VERSION}/${AXELARD_BINARY} -o "${AXELARD}" && chmod +x "${AXELARD}"
 fi
 
 if [ ! -f "${CONFIG_DIRECTORY}/genesis.json" ]; then
   echo "Downloading genesis.json"
-  curl -s https://axelar-testnet.s3.us-east-2.amazonaws.com/genesis.json -o "${CONFIG_DIRECTORY}/genesis.json"
+  curl -s --fail https://axelar-testnet.s3.us-east-2.amazonaws.com/genesis.json -o "${CONFIG_DIRECTORY}/genesis.json"
 fi
 
 if [ ! -f "${CONFIG_DIRECTORY}/peers.txt" ]; then
   echo "Downloading peers.txt"
-  curl -s https://axelar-testnet.s3.us-east-2.amazonaws.com/peers.txt -o "${CONFIG_DIRECTORY}/peers.txt"
+  curl -s --fail https://axelar-testnet.s3.us-east-2.amazonaws.com/peers.txt -o "${CONFIG_DIRECTORY}/peers.txt"
 fi
 
 if [ ! -f "${CONFIG_DIRECTORY}/config.toml" ]; then

--- a/join/join-testnet-with-binaries.sh
+++ b/join/join-testnet-with-binaries.sh
@@ -52,7 +52,7 @@ addPeers() {
   mv "$CONFIG_DIRECTORY/config.toml.tmp" "$CONFIG_DIRECTORY/config.toml"
 }
 
-# override OS with amd64 for x86 arch
+# override ARCH with amd64 for x86 arch
 if [ "x86_64" =  "$ARCH" ]; then
   ARCH=amd64
 fi

--- a/join/join-testnet-with-binaries.sh
+++ b/join/join-testnet-with-binaries.sh
@@ -53,8 +53,8 @@ addPeers() {
 }
 
 # override OS with amd64 for x86 arch
-if [ "x86_64" =  "$OS" ]; then
-  OS=amd64
+if [ "x86_64" =  "$ARCH" ]; then
+  ARCH=amd64
 fi
 
 echo "Axelar Core Version: ${AXELAR_CORE_VERSION}"

--- a/join/launch-validator-with-binaries.sh
+++ b/join/launch-validator-with-binaries.sh
@@ -95,7 +95,7 @@ mkdir -p "$CONFIG_DIRECTORY"
 TOFND_BINARY="tofnd-${OS}-${ARCH}-${TOFND_VERSION}"
 if [ ! -f "${TOFND}" ]; then
   echo "Downloading tofnd binary $TOFND_BINARY"
-  curl -s https://axelar-releases.s3.us-east-2.amazonaws.com/tofnd/${TOFND_VERSION}/${TOFND_BINARY} -o "${TOFND}" && chmod +x "${TOFND}"
+  curl -s --fail https://axelar-releases.s3.us-east-2.amazonaws.com/tofnd/${TOFND_VERSION}/${TOFND_BINARY} -o "${TOFND}" && chmod +x "${TOFND}"
 fi
 
 if [ ! -f "${CONFIG_DIRECTORY}/config.toml" ]; then

--- a/join/launch-validator-with-binaries.sh
+++ b/join/launch-validator-with-binaries.sh
@@ -67,6 +67,11 @@ if [ -z "$TOFND_VERSION" ]; then
   exit 1
 fi
 
+# override OS with amd64 for x86 arch
+if [ "x86_64" =  "$ARCH" ]; then
+  ARCH=amd64
+fi
+
 echo "TOFND Version: ${TOFND_VERSION}"
 echo "Axelar Core Version: ${AXELAR_CORE_VERSION}"
 echo "OS: ${OS}"

--- a/join/launch-validator-with-binaries.sh
+++ b/join/launch-validator-with-binaries.sh
@@ -67,7 +67,7 @@ if [ -z "$TOFND_VERSION" ]; then
   exit 1
 fi
 
-# override OS with amd64 for x86 arch
+# override ARCH with amd64 for x86 arch
 if [ "x86_64" =  "$ARCH" ]; then
   ARCH=amd64
 fi


### PR DESCRIPTION
Allow script to fail when binary not downloaded
Override arch with amd64 when its x86_64