### PR TITLE
fix: broken links to setup page

### DIFF
--- a/documentation/Admin/validator-extra-commands.md
+++ b/documentation/Admin/validator-extra-commands.md
@@ -13,7 +13,7 @@ Axelar Network is a work in progress. At no point in time should you transfer an
 :::
 
 ## Prerequisites
-- Complete all steps from [Setup with Docker](/setup-with-docker.md) or [Setup with Binaries](/setup-with-binaries.md)
+- Complete all steps from [Setup with Docker](/setup-docker.md) or [Setup with Binaries](/setup-binaries.md)
 - Attempted or completed [Excercise 3](/exercises/e3) to join the network as a validator, and have a basic understanding of the workflow
 
 ## Commands

--- a/documentation/Admin/validator-extra-commands.md
+++ b/documentation/Admin/validator-extra-commands.md
@@ -13,7 +13,7 @@ Axelar Network is a work in progress. At no point in time should you transfer an
 :::
 
 ## Prerequisites
-- Complete all steps from [Setup with Docker](/setup-docker.md) or [Setup with Binaries](/setup-binaries.md)
+- Complete all steps from [Setup with Docker](/setup-docker) or [Setup with Binaries](/setup-binaries)
 - Attempted or completed [Excercise 3](/exercises/e3) to join the network as a validator, and have a basic understanding of the workflow
 
 ## Commands

--- a/documentation/docs/Common Problems And Their Solutions/_category_.json
+++ b/documentation/docs/Common Problems And Their Solutions/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Common Problems And Their Solutions",
-  "position": 5
+  "position": 6
 }

--- a/documentation/docs/Exercises/Exercise 1.md
+++ b/documentation/docs/Exercises/Exercise 1.md
@@ -16,7 +16,7 @@ Axelar Network is a work in progress. At no point in time should you transfer an
 :::
 
 ## Prerequisites
-- Complete all steps from [Setup with Docker](/setup-docker.md) or [Setup with Binaries](/setup-binaries.md)
+- Complete all steps from [Setup with Docker](/setup-docker) or [Setup with Binaries](/setup-binaries)
 - Have a Ethereum wallet setup with [MEW](https://www.myetherwallet.com/) and have an Ethereum address funded with some Ether (You can also choose to use the [Chrome plugin](https://chrome.google.com/webstore/detail/mew-cx/nlbmnnijcnlegkjjpcfjclmcfggfefdm?hl=en))
 
 ## Useful links
@@ -34,7 +34,7 @@ Axelar Network is a work in progress. At no point in time should you transfer an
 
 ## Joining the Axelar testnet
 
-Follow the instructions in [Setup with Docker](/setup-docker.md) or [Setup with Binaries](/setup-binaries.md) to make sure your node is up to date and you received some test coins to your validator account.
+Follow the instructions in [Setup with Docker](/setup-docker) or [Setup with Binaries](/setup-binaries) to make sure your node is up to date and you received some test coins to your validator account.
 
 ## Instructions to mint and burn tokens
 These instructions are a step by step guide to run commands to move an asset from a source to a destination chain and back. The assets are minted as wrapped ERC-20 assets on the destination chain. The commands are submitted to the Axelar Network that's responsible for (a) generating deposit/withdrawal addresses, (b) routing and finalizing transactions, and (c) minting/burning the corresponding assets.

--- a/documentation/docs/Exercises/Exercise 1.md
+++ b/documentation/docs/Exercises/Exercise 1.md
@@ -16,7 +16,7 @@ Axelar Network is a work in progress. At no point in time should you transfer an
 :::
 
 ## Prerequisites
-- Complete all steps from [Setup with Docker](/setup-with-docker.md) or [Setup with Binaries](/setup-with-binaries.md)
+- Complete all steps from [Setup with Docker](/setup-docker.md) or [Setup with Binaries](/setup-binaries.md)
 - Have a Ethereum wallet setup with [MEW](https://www.myetherwallet.com/) and have an Ethereum address funded with some Ether (You can also choose to use the [Chrome plugin](https://chrome.google.com/webstore/detail/mew-cx/nlbmnnijcnlegkjjpcfjclmcfggfefdm?hl=en))
 
 ## Useful links
@@ -34,7 +34,7 @@ Axelar Network is a work in progress. At no point in time should you transfer an
 
 ## Joining the Axelar testnet
 
-Follow the instructions in [Setup with Docker](/setup-with-docker.md) or [Setup with Binaries](/setup-with-binaries.md) to make sure your node is up to date and you received some test coins to your validator account.
+Follow the instructions in [Setup with Docker](/setup-docker.md) or [Setup with Binaries](/setup-binaries.md) to make sure your node is up to date and you received some test coins to your validator account.
 
 ## Instructions to mint and burn tokens
 These instructions are a step by step guide to run commands to move an asset from a source to a destination chain and back. The assets are minted as wrapped ERC-20 assets on the destination chain. The commands are submitted to the Axelar Network that's responsible for (a) generating deposit/withdrawal addresses, (b) routing and finalizing transactions, and (c) minting/burning the corresponding assets.

--- a/documentation/docs/Exercises/Exercise 2.md
+++ b/documentation/docs/Exercises/Exercise 2.md
@@ -23,7 +23,7 @@ Axelar Network is a work in progress. At no point in time should you transfer an
 :::
 
 ## Prerequisites
-- Complete all steps from [Setup with Docker](/setup-docker.md) or [Setup with Binaries](/setup-binaries.md)
+- Complete all steps from [Setup with Docker](/setup-docker) or [Setup with Binaries](/setup-binaries)
 
 ## Useful links
 - [Extra commands to query Axelar Network state](/extra-commands)
@@ -35,7 +35,7 @@ Axelar Network is a work in progress. At no point in time should you transfer an
 
 ## Joining the Axelar testnet
 
-Follow the instructions in [Setup with Docker](/setup-docker.md) or [Setup with Binaries](/setup-binaries.md) to make sure your node is synchronized to the latest block, and you have received some test coins to your validator account.
+Follow the instructions in [Setup with Docker](/setup-docker) or [Setup with Binaries](/setup-binaries) to make sure your node is synchronized to the latest block, and you have received some test coins to your validator account.
 
 ### Pull and enter the c2d2cli container
 Check [Testnet Release](/testnet-releases) for the latest available C2D2 version of the docker images.

--- a/documentation/docs/Exercises/Exercise 2.md
+++ b/documentation/docs/Exercises/Exercise 2.md
@@ -23,7 +23,7 @@ Axelar Network is a work in progress. At no point in time should you transfer an
 :::
 
 ## Prerequisites
-- Complete all steps from [Setup with Docker](/setup-with-docker.md) or [Setup with Binaries](/setup-with-binaries.md)
+- Complete all steps from [Setup with Docker](/setup-docker.md) or [Setup with Binaries](/setup-binaries.md)
 
 ## Useful links
 - [Extra commands to query Axelar Network state](/extra-commands)
@@ -35,7 +35,7 @@ Axelar Network is a work in progress. At no point in time should you transfer an
 
 ## Joining the Axelar testnet
 
-Follow the instructions in [Setup with Docker](/setup-with-docker.md) or [Setup with Binaries](/setup-with-binaries.md) to make sure your node is synchronized to the latest block, and you have received some test coins to your validator account.
+Follow the instructions in [Setup with Docker](/setup-docker.md) or [Setup with Binaries](/setup-binaries.md) to make sure your node is synchronized to the latest block, and you have received some test coins to your validator account.
 
 ### Pull and enter the c2d2cli container
 Check [Testnet Release](/testnet-releases) for the latest available C2D2 version of the docker images.

--- a/documentation/docs/Exercises/Exercise 3.md
+++ b/documentation/docs/Exercises/Exercise 3.md
@@ -16,7 +16,7 @@ Axelar Network is a work in progress. At no point in time should you transfer an
 :::
 
 ## Prerequisites
-- Complete all steps from [Setup with Docker](/setup-with-docker.md) or [Setup with Binaries](/setup-with-binaries.md)
+- Complete all steps from [Setup with Docker](/setup-docker.md) or [Setup with Binaries](/setup-binaries.md)
 
 ## Useful links
 - [Axelar faucet](http://faucet.testnet.axelar.network/)
@@ -29,7 +29,7 @@ Axelar Network is a work in progress. At no point in time should you transfer an
 
 ## Joining the Axelar testnet
 
-Follow the instructions in [Setup with Docker](/setup-with-docker.md) or [Setup with Binaries](/setup-with-binaries.md) to make sure your node is up to date.
+Follow the instructions in [Setup with Docker](/setup-docker.md) or [Setup with Binaries](/setup-binaries.md) to make sure your node is up to date.
 
 ## Instructions to mint and burn tokens
 These instructions are a step by step guide to run commands to move an asset from a source to a destination chain and back. The assets are minted as wrapped assets on the Axelar Network. The commands are submitted to the Axelar Network that's responsible for (a) generating deposit/withdrawal addresses, (b) routing and finalizing transactions, and (c) minting/burning the corresponding assets.

--- a/documentation/docs/Exercises/Exercise 3.md
+++ b/documentation/docs/Exercises/Exercise 3.md
@@ -16,7 +16,7 @@ Axelar Network is a work in progress. At no point in time should you transfer an
 :::
 
 ## Prerequisites
-- Complete all steps from [Setup with Docker](/setup-docker.md) or [Setup with Binaries](/setup-binaries.md)
+- Complete all steps from [Setup with Docker](/setup-docker) or [Setup with Binaries](/setup-binaries)
 
 ## Useful links
 - [Axelar faucet](http://faucet.testnet.axelar.network/)
@@ -29,7 +29,7 @@ Axelar Network is a work in progress. At no point in time should you transfer an
 
 ## Joining the Axelar testnet
 
-Follow the instructions in [Setup with Docker](/setup-docker.md) or [Setup with Binaries](/setup-binaries.md) to make sure your node is up to date.
+Follow the instructions in [Setup with Docker](/setup-docker) or [Setup with Binaries](/setup-binaries) to make sure your node is up to date.
 
 ## Instructions to mint and burn tokens
 These instructions are a step by step guide to run commands to move an asset from a source to a destination chain and back. The assets are minted as wrapped assets on the Axelar Network. The commands are submitted to the Axelar Network that's responsible for (a) generating deposit/withdrawal addresses, (b) routing and finalizing transactions, and (c) minting/burning the corresponding assets.

--- a/documentation/docs/Exercises/Exercise 4.md
+++ b/documentation/docs/Exercises/Exercise 4.md
@@ -16,7 +16,7 @@ Axelar Network is a work in progress. At no point in time should you transfer an
 :::
 
 ## Prerequisites
-- Complete all steps from [Setup with Docker](/setup-with-docker.md) or [Setup with Binaries](/setup-with-binaries.md)
+- Complete all steps from [Setup with Docker](/setup-docker.md) or [Setup with Binaries](/setup-binaries.md)
 - Golang (Follow the [official docs](https://golang.org/doc/install) to install)
 
 ## Useful links
@@ -26,7 +26,7 @@ Axelar Network is a work in progress. At no point in time should you transfer an
 
 ## Joining the Axelar testnet
 
-Follow the instructions in [Setup with Docker](/setup-with-docker.md) or [Setup with Binaries](/setup-with-binaries.md) to make sure your node is up to date, and you received some test coins to your account.
+Follow the instructions in [Setup with Docker](/setup-docker.md) or [Setup with Binaries](/setup-binaries.md) to make sure your node is up to date, and you received some test coins to your account.
 
 ## Connect to the Cosmoshub testnet
 

--- a/documentation/docs/Exercises/Exercise 4.md
+++ b/documentation/docs/Exercises/Exercise 4.md
@@ -16,7 +16,7 @@ Axelar Network is a work in progress. At no point in time should you transfer an
 :::
 
 ## Prerequisites
-- Complete all steps from [Setup with Docker](/setup-docker.md) or [Setup with Binaries](/setup-binaries.md)
+- Complete all steps from [Setup with Docker](/setup-docker) or [Setup with Binaries](/setup-binaries)
 - Golang (Follow the [official docs](https://golang.org/doc/install) to install)
 
 ## Useful links
@@ -26,7 +26,7 @@ Axelar Network is a work in progress. At no point in time should you transfer an
 
 ## Joining the Axelar testnet
 
-Follow the instructions in [Setup with Docker](/setup-docker.md) or [Setup with Binaries](/setup-binaries.md) to make sure your node is up to date, and you received some test coins to your account.
+Follow the instructions in [Setup with Docker](/setup-docker) or [Setup with Binaries](/setup-binaries) to make sure your node is up to date, and you received some test coins to your account.
 
 ## Connect to the Cosmoshub testnet
 

--- a/documentation/docs/Exercises/Exercise 5.md
+++ b/documentation/docs/Exercises/Exercise 5.md
@@ -16,7 +16,7 @@ Axelar Network is a work in progress. At no point in time should you transfer an
 :::
 
 ## Prerequisites
-- Complete all steps from [Setup with Docker](/setup-with-docker.md) or [Setup with Binaries](/setup-with-binaries.md)
+- Complete all steps from [Setup with Docker](/setup-docker.md) or [Setup with Binaries](/setup-binaries.md)
 - Have a Ethereum wallet setup and have an Ethereum address funded with some Ether (You can also choose to use the [Chrome plugin](https://chrome.google.com/webstore/detail/mew-cx/nlbmnnijcnlegkjjpcfjclmcfggfefdm?hl=en))
 - Your Axelar Network address have`satoshi` and `uphoton (ibc/287EE075B7AADDEB240AFE74FA2108CDACA50A7CCD013FA4C1FCD142AFA9CA9A)` balances. If you do not have these assets, please follow `Exercise 3` and `Exercise 4` to mint some.
 
@@ -31,7 +31,7 @@ Axelar Network is a work in progress. At no point in time should you transfer an
 
 ## Joining the Axelar testnet
 
-Follow the instructions in [Setup with Docker](/setup-with-docker.md) or [Setup with Binaries](/setup-with-binaries.md) to make sure your node is up to date and you received some test coins to your account.
+Follow the instructions in [Setup with Docker](/setup-docker.md) or [Setup with Binaries](/setup-binaries.md) to make sure your node is up to date and you received some test coins to your account.
 
 
 ### Sending tokens from Axelar Network to Ethereum

--- a/documentation/docs/Exercises/Exercise 5.md
+++ b/documentation/docs/Exercises/Exercise 5.md
@@ -16,7 +16,7 @@ Axelar Network is a work in progress. At no point in time should you transfer an
 :::
 
 ## Prerequisites
-- Complete all steps from [Setup with Docker](/setup-docker.md) or [Setup with Binaries](/setup-binaries.md)
+- Complete all steps from [Setup with Docker](/setup-docker) or [Setup with Binaries](/setup-binaries)
 - Have a Ethereum wallet setup and have an Ethereum address funded with some Ether (You can also choose to use the [Chrome plugin](https://chrome.google.com/webstore/detail/mew-cx/nlbmnnijcnlegkjjpcfjclmcfggfefdm?hl=en))
 - Your Axelar Network address have`satoshi` and `uphoton (ibc/287EE075B7AADDEB240AFE74FA2108CDACA50A7CCD013FA4C1FCD142AFA9CA9A)` balances. If you do not have these assets, please follow `Exercise 3` and `Exercise 4` to mint some.
 
@@ -31,7 +31,7 @@ Axelar Network is a work in progress. At no point in time should you transfer an
 
 ## Joining the Axelar testnet
 
-Follow the instructions in [Setup with Docker](/setup-docker.md) or [Setup with Binaries](/setup-binaries.md) to make sure your node is up to date and you received some test coins to your account.
+Follow the instructions in [Setup with Docker](/setup-docker) or [Setup with Binaries](/setup-binaries) to make sure your node is up to date and you received some test coins to your account.
 
 
 ### Sending tokens from Axelar Network to Ethereum

--- a/documentation/docs/Exercises/_category_.json
+++ b/documentation/docs/Exercises/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Exercises",
-  "position": 3
+  "position": 4
 }

--- a/documentation/docs/extra-commands.md
+++ b/documentation/docs/extra-commands.md
@@ -13,7 +13,7 @@ Axelar Network is a work in progress. At no point in time should you transfer an
 :::
 
 ## Prerequisites
-- Complete all steps from [Setup with Docker](/setup-with-docker.md) or [Setup with Binaries](/setup-with-binaries.md)
+- Complete all steps from [Setup with Docker](/setup-docker.md) or [Setup with Binaries](/setup-binaries.md)
 - Attempted or completed [Excercise 1](/exercises/e1) and have a basic understanding of the asset transfer workflow
 
 ## Commands

--- a/documentation/docs/extra-commands.md
+++ b/documentation/docs/extra-commands.md
@@ -1,6 +1,6 @@
 ---
 id: extra-commands
-sidebar_position: 4
+sidebar_position: 5
 sidebar_label: Extra Commands
 slug: /extra-commands
 ---

--- a/documentation/docs/extra-commands.md
+++ b/documentation/docs/extra-commands.md
@@ -13,7 +13,7 @@ Axelar Network is a work in progress. At no point in time should you transfer an
 :::
 
 ## Prerequisites
-- Complete all steps from [Setup with Docker](/setup-docker.md) or [Setup with Binaries](/setup-binaries.md)
+- Complete all steps from [Setup with Docker](/setup-docker) or [Setup with Binaries](/setup-binaries)
 - Attempted or completed [Excercise 1](/exercises/e1) and have a basic understanding of the asset transfer workflow
 
 ## Commands

--- a/documentation/docs/setup-with-docker.md
+++ b/documentation/docs/setup-with-docker.md
@@ -6,7 +6,7 @@ slug: /setup-docker
 ---
 
 # Testnet Node Setup
-Tools to join the axelar network using docker images. For binaries checkout [Setup with Binaries](/setup-with-binaries.md).
+Tools to join the axelar network using docker images. For binaries checkout [Setup with Binaries](/setup-binaries.md).
 
 This tutorial will take 30-60 minutes of dev time and 2-4 hours of waiting for blockchain sync. The tutorial includes steps for joining the axelar network using two ways. A docker based setup and a setup using binaries. As per your preference, follow the steps for one of the two options.
 

--- a/documentation/docs/setup-with-docker.md
+++ b/documentation/docs/setup-with-docker.md
@@ -6,7 +6,7 @@ slug: /setup-docker
 ---
 
 # Testnet Node Setup
-Tools to join the axelar network using docker images. For binaries checkout [Setup with Binaries](/setup-binaries.md).
+Tools to join the axelar network using docker images. For binaries checkout [Setup with Binaries](/setup-binaries).
 
 This tutorial will take 30-60 minutes of dev time and 2-4 hours of waiting for blockchain sync. The tutorial includes steps for joining the axelar network using two ways. A docker based setup and a setup using binaries. As per your preference, follow the steps for one of the two options.
 

--- a/documentation/docs/testnet-releases.md
+++ b/documentation/docs/testnet-releases.md
@@ -1,6 +1,6 @@
 ---
 id: testnet-releases
-sidebar_position: 8
+sidebar_position: 7
 sidebar_label: Testnet Release
 slug: /testnet-releases
 ---

--- a/documentation/docs/welcome.md
+++ b/documentation/docs/welcome.md
@@ -6,4 +6,4 @@ sidebar_position: 1
 # Welcome To Axelar Network Testnet
 ![img](../docs/images/Axelar.png)
 
-Visit the [Setup with Docker](/setup-docker.md) or [Setup with Binaries](/setup-binaries.md) page to get started
+Visit the [Setup with Docker](/setup-docker) or [Setup with Binaries](/setup-binaries) page to get started

--- a/documentation/docs/welcome.md
+++ b/documentation/docs/welcome.md
@@ -6,4 +6,4 @@ sidebar_position: 1
 # Welcome To Axelar Network Testnet
 ![img](../docs/images/Axelar.png)
 
-Visit the [Setup with Docker](/setup-with-docker.md) or [Setup with Binaries](/setup-with-binaries.md) page to get started
+Visit the [Setup with Docker](/setup-docker.md) or [Setup with Binaries](/setup-binaries.md) page to get started

--- a/documentation/docusaurus.config.js
+++ b/documentation/docusaurus.config.js
@@ -40,8 +40,8 @@ module.exports = {
       },
       items: [
         {
-          to: "/setup",
-          activeBasePath: "/setup",
+          to: "/setup-docker",
+          activeBasePath: "/setup-docker",
           position: "left",
           label: "Setup",
         },
@@ -100,7 +100,7 @@ module.exports = {
           items: [
             {
               label: "Setup",
-              to: "/setup",
+              to: "/setup-docker",
             },
             {
               label: "Testnet Release Versions",

--- a/documentation/docusaurus.config.js
+++ b/documentation/docusaurus.config.js
@@ -40,12 +40,6 @@ module.exports = {
       },
       items: [
         {
-          to: "/setup-docker",
-          activeBasePath: "/setup-docker",
-          position: "left",
-          label: "Setup",
-        },
-        {
           to: "/testnet-releases",
           activeBasePath: "/testnet-releases",
           position: "left",
@@ -92,23 +86,6 @@ module.exports = {
             {
               label: " Testnet Form Submission Portal",
               to: "https://axelar.knack.com/testnet-portal",
-            },
-          ],
-        },
-        {
-          title: "Docs",
-          items: [
-            {
-              label: "Setup",
-              to: "/setup-docker",
-            },
-            {
-              label: "Testnet Release Versions",
-              to: "/testnet-releases",
-            },
-            {
-              label: "FAQs",
-              to: "/problem/p1",
             },
           ],
         },


### PR DESCRIPTION
Currently, the Github repo and the Vercel website are out of sync because Vercel deployments are failing due to broken links.

This PR fixes these broken links to update the website with our latest github changes. In the future, we will enforce a passing check from vercel bot before allowing PR merge