### PR TITLE
Fixing testnet-release.md location

### DIFF
--- a/documentation/docs/Exercises/Exercise 4.md
+++ b/documentation/docs/Exercises/Exercise 4.md
@@ -93,7 +93,7 @@ gaiad q bank balances [cosmoshub address]
 ### Instructions to send tokens from Cosmoshub testnet to Axelar Network
 1. Send an IBC transfer from Cosmoshub testnet to Axelar Network
 
-You can find `Cosmoshub channel id` under [Testnet Release](/testnet-releases.md)
+You can find `Cosmoshub channel id` under [Testnet Release](../testnet-releases.md)
 
 [axelar address] is the address you generated in Exercise 3
 


### PR DESCRIPTION
Broken link to https://github.com/axelarnetwork/axelarate-community/blob/main/documentation/docs/testnet-releases.md, fixed it.