### PR TITLE
Fixing extra-commands broken link

### DIFF
--- a/documentation/docs/Exercises/Exercise 3.md
+++ b/documentation/docs/Exercises/Exercise 3.md
@@ -23,7 +23,7 @@ Axelar Network is a work in progress. At no point in time should you transfer an
 - Latest docker image: https://hub.docker.com/repository/docker/axelarnet/axelar-core
 - Exercise 3 [walkthrough video](https://youtu.be/ggngYFa0AnQ) using Docker 
   + Completed on Axelar core version v0.7.6, be careful of potential differences in the workflow
-- [Extra commands](/extra-commands) to query Axelar Network state
+- [Extra commands](../extra-commands.md) to query Axelar Network state
 
 ## What you need
 - Bitcoin testnet faucet to send some test BTC: https://testnet-faucet.mempool.co/


### PR DESCRIPTION
The extra-commands was broken, should point to https://github.com/axelarnetwork/axelarate-community/blob/main/documentation/docs/extra-commands.md, fixed now.