### PR TITLE
chore: add --dev flag to prevent accidental use of main branch

### DIFF
--- a/join/join-testnet.sh
+++ b/join/join-testnet.sh
@@ -42,7 +42,7 @@ for arg in "$@"; do
   esac
 done
 
-if $STOP_ME; then
+if [ "$(git rev-parse --abbrev-ref HEAD)" == "main" ] && $STOP_ME; then
   echo "Please checkout the correct version tag. See README for instructions."
   exit 1
 fi

--- a/join/join-testnet.sh
+++ b/join/join-testnet.sh
@@ -3,6 +3,7 @@
 AXELAR_CORE_VERSION="$(curl -s https://raw.githubusercontent.com/axelarnetwork/axelarate-community/main/documentation/docs/testnet-releases.md  | grep axelar-core | cut -d \` -f 4)"
 TOFND_VERSION="$(curl -s https://raw.githubusercontent.com/axelarnetwork/axelarate-community/main/documentation/docs/testnet-releases.md  | grep tofnd | cut -d \` -f 4)"
 RESET_CHAIN=false
+STOP_ME=true
 ROOT_DIRECTORY=~/.axelar_testnet
 GIT_ROOT="$(git rev-parse --show-toplevel)"
 TENDERMINT_KEY_PATH=""
@@ -11,6 +12,10 @@ DOCKER_NETWORK="axelarate_default"
 
 for arg in "$@"; do
   case $arg in
+    --dev)
+    STOP_ME=false
+    shift
+    ;;
     --validator-mnemonic)
     AXELAR_MNEMONIC_PATH="$2"
     shift
@@ -36,6 +41,11 @@ for arg in "$@"; do
     ;;
   esac
 done
+
+if $STOP_ME; then
+  echo "Please checkout the correct version tag. See README for instructions."
+  exit 1
+fi
 
 if [ -z "$AXELAR_CORE_VERSION" ]; then
   echo "'--axelar-core vX.Y.Z' is required"


### PR DESCRIPTION
Some users accidentally run `join-testnet.sh` from `main` branch instead of the appropriate version tag.  This PR makes `join-testnet.sh` terminate with an error:
```
Please checkout the correct version tag. See README for instructions.
```
unless the user sets the `--dev` flag.