### PR TITLE
[join-Testnet.sh] add pause after docker run

### DIFF
--- a/join/join-testnet.sh
+++ b/join/join-testnet.sh
@@ -125,7 +125,7 @@ docker run                                             \
   -v "${SHARED_DIRECTORY}:/root/shared"                \
   "axelarnet/axelar-core:${AXELAR_CORE_VERSION}" startNodeProc
 
-pause 5
+sleep 5
 
 VALIDATOR=$(docker exec axelar-core sh -c "axelard keys show validator -a --bech val")
 

--- a/join/join-testnet.sh
+++ b/join/join-testnet.sh
@@ -125,6 +125,8 @@ docker run                                             \
   -v "${SHARED_DIRECTORY}:/root/shared"                \
   "axelarnet/axelar-core:${AXELAR_CORE_VERSION}" startNodeProc
 
+pause 5
+
 VALIDATOR=$(docker exec axelar-core sh -c "axelard keys show validator -a --bech val")
 
 echo

--- a/join/join-testnet.sh
+++ b/join/join-testnet.sh
@@ -125,6 +125,7 @@ docker run                                             \
   -v "${SHARED_DIRECTORY}:/root/shared"                \
   "axelarnet/axelar-core:${AXELAR_CORE_VERSION}" startNodeProc
 
+echo "Wait 5 seconds for axelar-core to start..."
 sleep 5
 
 VALIDATOR=$(docker exec axelar-core sh -c "axelard keys show validator -a --bech val")


### PR DESCRIPTION
Adding pause allow the axelar-core container to run long enough so the docker exec  can run with success later.