### PR TITLE
doc: Upgrade axelar-core to v0.8.5

### DIFF
--- a/documentation/docs/testnet-releases.md
+++ b/documentation/docs/testnet-releases.md
@@ -9,8 +9,8 @@ slug: /testnet-releases
 
 Variable  | Value
 ------------- | -------------
-`axelar-core` version | `v0.8.4`
-`axelarate-community` version | `v0.7.6`
+`axelar-core` version | `v0.8.5`
+`axelarate-community` version | `v0.7.7`
 `tofnd` version | `v0.7.1`
 `c2d2` version | `inactive`
 Ethereum Axelar Gateway contract address | `0x8065A890A99Aa275bc54CB59c078D7e30c9D6a98`

--- a/documentation/docs/upgrade-v0.8.5.md
+++ b/documentation/docs/upgrade-v0.8.5.md
@@ -1,0 +1,33 @@
+---
+id: upgrace-v0.8.5
+sidebar_position: 10
+sidebar_label: Upgrade to v0.8.5
+slug: /upgrade-v0.8.5
+---
+
+# How to upgrade your node to v0.8.5
+
+Please perform this process sometime before 14:30 UTC on Friday, 2021-nov-26.
+
+## Ordinary (non-validator) nodes: Docker
+
+TL;DR
+```
+docker stop axelar-core
+cp -r ~/.axelar_testnet ~/.axelar_testnet_backup
+./join/join-testnet.sh --axelar-core v0.8.5
+```
+
+Upgrade is very simple---just restart your node.  The `cp` command above creates a backup copy of your testnet data.  If something goes wrong then you can restore your node's state from the backup.
+
+## Validator nodes: Docker
+
+TL;DR
+```
+docker stop axelar-core vald tofnd
+cp -r ~/.axelar_testnet ~/.axelar_testnet_backup
+./join/join-testnet.sh --axelar-core v0.8.5
+./join/launch-validator-tools.sh --axelar-core v0.8.5
+```
+
+Like upgrading a non-validator node---just restart your node.  As above, the `cp` command creates a backup copy of your testnet data in case something goes wrong.

--- a/documentation/docs/upgrade-v0.8.5.md
+++ b/documentation/docs/upgrade-v0.8.5.md
@@ -1,5 +1,5 @@
 ---
-id: upgrace-v0.8.5
+id: upgrade-v0.8.5
 sidebar_position: 10
 sidebar_label: Upgrade to v0.8.5
 slug: /upgrade-v0.8.5

--- a/documentation/docs/upgrade-v0.8.5.md
+++ b/documentation/docs/upgrade-v0.8.5.md
@@ -7,7 +7,11 @@ slug: /upgrade-v0.8.5
 
 # How to upgrade your node to v0.8.5
 
-Please perform this process sometime before 14:30 UTC on Friday, 2021-nov-26.
+:::warning
+Please perform this upgrade process sometime before 14:30 UTC on Friday, 2021-nov-26.
+
+After that time, nodes running any version of axelar-core prior to v0.8.5 will fall out of consensus with testnet.
+:::
 
 Checkout verion 0.7.7 of axelarate-community.  In your local axelarate-community repo:
 ```

--- a/documentation/docs/upgrade-v0.8.5.md
+++ b/documentation/docs/upgrade-v0.8.5.md
@@ -9,7 +9,17 @@ slug: /upgrade-v0.8.5
 
 Please perform this process sometime before 14:30 UTC on Friday, 2021-nov-26.
 
-## Ordinary (non-validator) nodes: Docker
+Checkout verion 0.7.7 of axelarate-community.  In your local axelarate-community repo:
+```
+git checkout v0.7.7
+```
+
+:::note
+All terminal commands in this document should be run in your local axelarate-community repo.
+:::
+## Docker
+
+### Ordinary (non-validator) nodes
 
 TL;DR
 ```
@@ -20,7 +30,7 @@ cp -r ~/.axelar_testnet ~/.axelar_testnet_backup
 
 Upgrade is very simple---just restart your node.  The `cp` command above creates a backup copy of your testnet data.  If something goes wrong then you can restore your node's state from the backup.
 
-## Validator nodes: Docker
+## Validator nodes
 
 TL;DR
 ```
@@ -31,3 +41,30 @@ cp -r ~/.axelar_testnet ~/.axelar_testnet_backup
 ```
 
 Like upgrading a non-validator node---just restart your node.  As above, the `cp` command creates a backup copy of your testnet data in case something goes wrong.
+
+## Binaries
+
+### Ordinary (non-validator) nodes
+
+TL;DR
+```
+kill -9 $(pgrep -f "axelard start")
+cp -r ~/.axelar_testnet ~/.axelar_testnet_backup
+./join/join-testnet-with-binaries.sh --axelar-core v0.8.5
+```
+
+As with docker, the `cp` command creates a backup copy of your testnet data in case something goes wrong.
+
+## Validator nodes
+
+TL;DR
+```
+kill -9 $(pgrep tofnd)
+kill -9 $(pgrep -f "axelard vald-start")
+kill -9 $(pgrep -f "axelard start")
+cp -r ~/.axelar_testnet ~/.axelar_testnet_backup
+./join/join-testnet-with-binaries.sh --axelar-core v0.8.5
+./join/launch-validator-tools-with-binaries.sh --axelar-core v0.8.5
+```
+
+As with docker, the `cp` command creates a backup copy of your testnet data in case something goes wrong.


### PR DESCRIPTION
- [x] BEFORE MERGE: https://github.com/axelarnetwork/axelarate/pull/395 must be merged first.
- [x] TODO: upgrade docs for binary.  (Currently have docker only.)
- [ ] AFTER MERGE: push a new tag `v0.7.7` tag to this repo.

Note: the flag `--axelar-core v0.8.5` is not actually necessary after this merge.  For simplicity we might remove it from the docs.  I put it there only for clarity to users.