### PR TITLE
chore: update testnet releases for lisbon-2

### DIFF
--- a/resources/testnet-releases.md
+++ b/resources/testnet-releases.md
@@ -3,27 +3,27 @@
 
 Variable  | Value
 ------------- | -------------
-`axelar-core` version | `v0.12.0`
+`axelar-core` version | `v0.10.7`
 `tofnd` version | `v0.8.2`
-Ethereum Axelar Gateway contract address | `0xE42A7b9C0Bb4EB0c08EFA52fBae4adFBD0348AcC`
-Ethereum AXL token address | `0x1E55BE2FE4D71Bf45eEdEc809365F90115bB0362`
-Ethereum UST token address | `0xe94e772F5437EBB144F2b3d9FDe911233131F19A`
-Ethereum LUNA token address | `0x2588eb8158971701e2C25591578B5F4F7c520653`
-Avalanche Axelar Gateway contract address | `0xB97Ba950Cd17F668E63480EEE58DaB56f6C8501D`
-Avalanche AXL token address | `0xF4D30bF0b8B4CFF10658B282BC7F5b9606efc9Fd`
-Avalanche UST token address | `0xC9c96a168585B3422c03e35679B4d41ce7377a8B`
-Avalanche LUNA token address | `0xAA03b8bdE7758A0cFd96A85AC95503fE80729E6d`
-Fantom Axelar Gateway contract address | `0x351bc4CB6d5D22368dBCc9A1cd36fd94a77f185C`
-Fantom AXL token address | `0x172af5304d42Fd988B35a71e242550f24f6Db8BD`
-Fantom UST token address | `0xaA33C9a10af29DCEb661c8E2eE3aA88f767387d0`
-Fantom LUNA token address | `0xc8e4F958BB297B2055508583290f93daaFFfafce`
-Polygon Axelar Gateway contract address | `0x4f7aCaC29526c9CDEEA07815c4aD0Af1588778eF`
-Polygon AXL token address | `0xa4dCE5380C596aa421C3949a8E215dFD8f63aC27`
-Polygon UST token address | `0x715d9E89A69535A9b563D991ad03f686b27AaA9d`
-Polygon LUNA token address | `0x1760d4A5ADeB525c94ddf7858423a1f8d35656cB`
-Moonbeam Axelar Gateway contract address | `0xec11b641ee3963E1D286798E973D652e2888590d`
-Moonbeam AXL token address | `0x3c6cB7DFC8B75f4B90a891679bAA8bEB10671F2b`
-Moonbeam UST token address | `0xfA295D0221c9fBc10Bb49fe8895e53A5E6dAF844`
-Moonbeam LUNA token address | `0x80f2e45283C6459388BDb1bBAFC6db2C67dc9640`
-Terra channel id | `channel-52`
-Axelar channel id | `channel-0`
+Ethereum Axelar Gateway contract address | `0x81b450CA8F0e842EcC361FD64270aeb5A374A0d8`
+Ethereum AXL token address | `0xBf96Dfc6AE44e880681b7221deE21E900BC0F21c`
+Ethereum UST token address | `0x5f1E1bdc2c73EFA2eEEe6b30128d968791D1c55C`
+Ethereum LUNA token address | `0xB7454D02D4190dAe72be2051482aCF044435C5D8`
+Avalanche Axelar Gateway contract address | `0x8F19fF12a38aDa314e6fC2611E75473BBb11FebE`
+Avalanche AXL token address | `0x5a3cF244040Ab7C8e6B192E8eb8eF6C78C9D612b`
+Avalanche UST token address | `0x0749e7902520ab6b3DBD28a1203A2d358700655e`
+Avalanche LUNA token address | `0x28EE721a8128ee8ff57f14b131535E05b88fd636`
+Fantom Axelar Gateway contract address | `0xdCE436d858Cfc7d46946d8f95B466e37FA897A4a`
+Fantom AXL token address | `0x0efE77aEf986684650c84C149e0e37196D9b7abc`
+Fantom UST token address | `0x243615425b166719A13875A5Dc044094DDF3dA4d`
+Fantom LUNA token address | `0x79e1b09d919AE79D039BB81BEB7c53C70f95719B`
+Polygon Axelar Gateway contract address | `0xa4dbF01D58C4C89B96194682e48b05c0dEC62201`
+Polygon AXL token address | `0x578aBd5AD95D0e85CB9b508295D4bC1B35496f8a`
+Polygon UST token address | `0x1912e95A44960c785e96d43651660aF55cA84ab8`
+Polygon LUNA token address | `0xaf11e7D46A146256D9178251CBe8A1e5E6218f90`
+Moonbeam Axelar Gateway contract address | `not yet available`
+Moonbeam AXL token address | `not yet available`
+Moonbeam UST token address | `not yet available`
+Moonbeam LUNA token address | `not yet available`
+Terra channel id | `not yet available`
+Axelar channel id | `not yet available`


### PR DESCRIPTION
not yet available
- [ ] Terra channel ids
- [ ] Moonbeam gateway, tokens.  (Moonbeam testnet currently down.)