### PR TITLE
fix: revert #330 and instead check before overwriting

### DIFF
--- a/scripts/node.sh
+++ b/scripts/node.sh
@@ -81,19 +81,7 @@ parse_params() {
   chain_id=''
   docker_network='axelarate_default'
   node_moniker="$(hostname | tr '[:upper:]' '[:lower:]')"
-
-  # Set the appropriate chain_id
-  if [ "$network" == "mainnet" ]; then
-    chain_id=axelar-dojo-1
-    root_directory="$HOME/.axelar"
-  elif [ "$network" == "testnet" ]; then
-    chain_id=axelar-testnet-lisbon-2
-    root_directory="$HOME/.axelar_testnet"
-  else
-    echo "Invalid network provided: ${network}"
-    exit 1
-  fi
-
+  
   while :; do
     case "${1-}" in
     -h | --help) usage ;;
@@ -139,6 +127,26 @@ parse_params() {
   done
 
   args=("$@")
+
+# Set the appropriate chain_id
+  if [ "$network" == "mainnet" ]; then
+    if [ -z "${chain_id}" ]; then
+      chain_id=axelar-dojo-1
+    fi
+    if [ -z "${root_directory}" ]; then
+      root_directory="$HOME/.axelar"
+    fi
+  elif [ "$network" == "testnet" ]; then
+    if [ -z "${chain_id}" ]; then
+    chain_id=axelar-testnet-lisbon-2
+    fi
+    if [ -z "${root_directory}" ]; then
+    root_directory="$HOME/.axelar_testnet"
+    fi
+  else
+    echo "Invalid network provided: ${network}"
+    exit 1
+  fi
 
   if [ -z "${axelar_core_version}" ]; then
     axelar_core_version="$(curl -s https://raw.githubusercontent.com/axelarnetwork/webdocs/main/docs/resources/"${network}"-releases.md  | grep axelar-core | cut -d \` -f 4)"

--- a/scripts/node.sh
+++ b/scripts/node.sh
@@ -141,7 +141,7 @@ parse_params() {
       chain_id=axelar-testnet-lisbon-2
     fi
     if [ -z "${root_directory}" ]; then
-    root_directory="$HOME/.axelar_testnet"
+      root_directory="$HOME/.axelar_testnet"
     fi
   else
     echo "Invalid network provided: ${network}"

--- a/scripts/node.sh
+++ b/scripts/node.sh
@@ -138,7 +138,7 @@ parse_params() {
     fi
   elif [ "$network" == "testnet" ]; then
     if [ -z "${chain_id}" ]; then
-    chain_id=axelar-testnet-lisbon-2
+      chain_id=axelar-testnet-lisbon-2
     fi
     if [ -z "${root_directory}" ]; then
     root_directory="$HOME/.axelar_testnet"


### PR DESCRIPTION
#330 doesn't work if user passes `-n mainnet`.  This PR reverts #330 and instead checks `root_directory` and `chain_id` before setting as suggested in https://github.com/axelarnetwork/axelarate-community/pull/330#discussion_r795918845

EDIT: Tested locally to verify that env vars are properly set with all combos of `-n` `-d` `-c`.