### PR TITLE
Fix URL for Axelar core version check.

### DIFF
--- a/scripts/node.sh
+++ b/scripts/node.sh
@@ -81,7 +81,7 @@ parse_params() {
   chain_id=''
   docker_network='axelarate_default'
   node_moniker="$(hostname | tr '[:upper:]' '[:lower:]')"
-  
+
   while :; do
     case "${1-}" in
     -h | --help) usage ;;
@@ -156,7 +156,7 @@ parse_params() {
   fi
 
   if [ -z "${axelar_core_version}" ]; then
-    axelar_core_version="$(curl -s https://raw.githubusercontent.com/axelarnetwork/webdocs/main/docs/releases/"${network}".md  | grep axelar-core | cut -d \` -f 4)"
+    axelar_core_version="$(curl -s https://raw.githubusercontent.com/axelarnetwork/webdocs/main/docs/resources/"${network}".md  | grep axelar-core | cut -d \` -f 4)"
   fi
 
   # check required params and arguments


### PR DESCRIPTION
This URL was changed in webdocs commit
177565b1853ad593214a67bed162dd5888c1ab7b from docs/releases to
docs/resources.

https://github.com/axelarnetwork/webdocs/commit/177565b1853ad593214a67bed162dd5888c1ab7b#diff-9d8b8908acf12d80be36c2b4027c8a5f374884f7452e8ad222ecae131bd69b2f