### PR TITLE
add parameter for specifying a validator key

### DIFF
--- a/scripts/validator-tools-host.sh
+++ b/scripts/validator-tools-host.sh
@@ -27,6 +27,7 @@ Available options:
 -a, --axelar-core-version     Version of axelar core to checkout
 -q, --tofnd-version           Version of tofnd to checkout
 -d, --root-directory          Directory for data. [default: $HOME/.axelar_testnet]
+-i, --validator-key-name      The name of the validator key. [default: validator]
 -n, --network                 Core Network to connect to [testnet|mainnet]
 -p, --proxy-mnemonic-path     Path to broadcaster mnemonic
 -z, --tofnd-mnemonic-path     Path to tofnd mnemonic
@@ -76,6 +77,7 @@ parse_params() {
   tofnd_version=""
   root_directory=""
   git_root="$(git rev-parse --show-toplevel)"
+  validator_key_name="validator"
   network="testnet"
   proxy_mnemonic_path='unset'
   tofnd_mnemonic_path='unset'
@@ -96,6 +98,10 @@ parse_params() {
       ;;
     -d | --root-directory)
       root_directory="${2-}"
+      shift
+      ;;
+    -i | --validator-key-name)
+      validator_key_name="${2-}"
       shift
       ;;
     -n | --network)
@@ -299,7 +305,7 @@ check_environment() {
       msg 'FAILED: tofnd already running. Run "kill -9 $(pgrep -f "tofnd")" to kill tofnd.'
       exit 1
     fi
-    
+
     if [ "$(pgrep -f 'axelard vald-start')" != "" ]; then
       # shellcheck disable=SC2016
       msg 'FAILED: vald already running. Run "kill -9 $(pgrep -f "axelard vald-start")" to kill vald.'
@@ -364,7 +370,7 @@ prepare() {
 
     echo "$KEYRING_PASSWORD" | "${axelard_binary_path}" keys show broadcaster -a --home "${vald_directory}"  > "${root_directory}/broadcaster.address" 2>&1
 
-    validator_address=$(echo "${KEYRING_PASSWORD}" | ${axelard_binary_path} keys show validator -a --bech val --home "${core_directory}")
+    validator_address=$(echo "${KEYRING_PASSWORD}" | ${axelard_binary_path} keys show ${validator_key_name} -a --bech val --home "${core_directory}")
     if [ -z "$validator_address" ]; then
       until [ -f "${root_directory}/validator.bech" ] ; do
         echo "Waiting for validator address to be accessible at ${root_directory}/validator.bech"
@@ -436,6 +442,7 @@ msg "- tofnd-mnemonic-path: ${tofnd_mnemonic_path}"
 #msg "- recovery-info-path: ${recovery_info_path}"
 msg "- network: ${network}"
 msg "- environment: ${environment}"
+msg "- validator-key-name: ${validator_key_name}"
 msg "- node-moniker: ${node_moniker}"
 msg "- script_dir: ${script_dir}"
 msg "- chain-id: ${chain_id}"


### PR DESCRIPTION
- This is helpful when the validator key name is name the default "validator"
- One such use case would be when the validator wants to setup a multi-sig account e.g. https://jake-hartnell.medium.com/cosmos-sdk-multisigs-96a390a9d3cc