### PR TITLE
fix: add seeds to config.toml

### DIFF
--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -66,6 +66,13 @@ copy_configuration_files() {
     if [ ! -f "${config_directory}/config.toml" ]; then
         msg "Copying config.toml to the config directory"
         cp "${git_root}/configuration/config.toml" "${config_directory}/config.toml"
+        # We build the line in the expected format,a comma separated list of seed nodes
+        SEEDS=$(cat "${config_directory}/seeds.toml" | grep address | awk '{print $3}' | tr -d '\n' | sed 's/""/,/g' | sed 's/^/seeds = /')
+        # We inject it in config.toml 
+        sed -i.bak "s/seeds = \"\"/$SEEDS/" "${config_directory}/config.toml"
+        # We remove the config.toml.bak (created because on Mac you have to create backup file with sed)
+        rm "${config_directory}/config.toml.bak"
+
     else
         msg "config.toml file already exists"
     fi

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -64,7 +64,7 @@ copy_configuration_files() {
     fi
 
     if [ ! -f "${config_directory}/config.toml" ]; then
-        msg "Copying config.toml to the config directory"
+        msg "Importing seeds from seeds.toml into config.toml, copying config.toml to the config directory"
         cp "${git_root}/configuration/config.toml" "${config_directory}/config.toml"
         # We build the line in the expected format,a comma separated list of seed nodes
         SEEDS=$(cat "${config_directory}/seeds.toml" | grep address | awk '{print $3}' | tr -d '\n' | sed 's/""/,/g' | sed 's/^/seeds = /')


### PR DESCRIPTION
PR to fix setup-node.sh for genesis sync : https://docs.axelar.dev/node/join-genesis

- setup-node.sh will call utils.sh. 

- We build the line in the expected format, a comma separated list of seed nodes

- We inject it in config.toml 

- We remove the config.toml.bak (created because on Mac you have to create backup file with sed), it is a Mac specificity.

if the binary version is inferior to 0.17, config.toml  file will be used and seeds will be found. If it superior, seeds.toml (current behaviour) will be used. Comparing the versions before injecting the line should not be required.
