### PR TITLE
chore: change pruning policy

### DIFF
--- a/configuration/app.toml
+++ b/configuration/app.toml
@@ -14,7 +14,7 @@ minimum-gas-prices = "0.00005uaxl"
 # nothing: all historic states will be saved, nothing will be deleted (i.e. archiving node)
 # everything: all saved states will be deleted, storing only the current state; pruning at 10 block intervals
 # custom: allow pruning options to be manually specified through 'pruning-keep-recent', 'pruning-keep-every', and 'pruning-interval'
-pruning = "default"
+pruning = "everything"
 
 # These are applied if and only if the pruning strategy is custom.
 pruning-keep-recent = "0"


### PR DESCRIPTION
Change pruning policy to `everything` to avoid building up memory in cache.