### PR TITLE
chore: increase node peering config to match our own nodes

### DIFF
--- a/configuration/config.toml
+++ b/configuration/config.toml
@@ -198,10 +198,10 @@ addr_book_file = "config/addrbook.json"
 addr_book_strict = true
 
 # Maximum number of inbound peers
-max_num_inbound_peers = 40
+max_num_inbound_peers = 100
 
 # Maximum number of outbound peers to connect to, excluding persistent peers
-max_num_outbound_peers = 10
+max_num_outbound_peers = 100
 
 # List of node IDs, to which a connection will be (re)established ignoring any existing limits
 unconditional_peer_ids = ""


### PR DESCRIPTION
Increasing `max_num_inbound_peers` and `max_num_outbound_peers` to match our own sentry/validator nodes

Possible solution to improve p2p connection in the network as we increase the active set. 