### PR TITLE
chore: update wasmvm dependency

### DIFF
--- a/scripts/node.sh
+++ b/scripts/node.sh
@@ -71,7 +71,7 @@ die() {
 parse_params() {
   # default values of variables set from params
   axelar_core_version=""
-  wasmvm_lib_version="v1.3.1"
+  wasmvm_lib_version="v1.5.8"
   reset_chain=0
   root_directory=''
   git_root="$(git rev-parse --show-toplevel)"

--- a/scripts/setup-host.sh
+++ b/scripts/setup-host.sh
@@ -81,7 +81,7 @@ download_dependencies() {
     if [[ "$arch" == "amd64" ]]; then wasm_lib="libwasmvm.x86_64.so"; fi
 
     wasm_lib_path="${share_lib_directory}/${wasm_lib}"
-    wasmvm_lib_version="v1.3.1"
+    wasmvm_lib_version="v1.5.8"
     msg "downloading wasm shared library ${wasmvm_lib_version}/${wasm_lib}"
 
     if [[ ! -f "${wasm_lib_path}" ]]; then

--- a/scripts/setup-node.sh
+++ b/scripts/setup-node.sh
@@ -31,7 +31,7 @@ EOF
 parse_params() {
     # default values of variables set from params
     axelar_core_version=""
-    wasmvm_lib_version="v1.3.1"
+    wasmvm_lib_version="v1.5.8"
     reset_chain=0
     root_directory=''
     git_root="$(git rev-parse --show-toplevel)"


### PR DESCRIPTION
axelard v1.2.1 updates wasmvm version to v1.5.8, requiring a binary runner update in dynamic linking