### PR TITLE
fix(scripts): remove the hardcoded wasmvm version by fetching the correct wasmvm version depending on the chosen axelar-core version

### DIFF
--- a/scripts/host.sh
+++ b/scripts/host.sh
@@ -106,14 +106,16 @@ download_dependencies() {
     if [[ "$arch" == "amd64" ]]; then wasm_lib="libwasmvm.x86_64.so"; fi
 
     wasm_lib_path="${share_lib_directory}/${wasm_lib}"
+    local wasm_version_marker="${share_lib_directory}/.wasmvm_version"
     msg "downloading wasm shared library ${wasmvm_lib_version}/${wasm_lib}"
 
-    if [[ ! -f "${wasm_lib_path}" ]]; then
+    if [[ ! -f "${wasm_lib_path}" ]] || [[ ! -f "${wasm_version_marker}" ]] || [[ "$(cat "${wasm_version_marker}")" != "${wasmvm_lib_version}" ]]; then
         local wasm_lib_url
         wasm_lib_url="https://github.com/CosmWasm/wasmvm/releases/download/${wasmvm_lib_version}"
         wget "${wasm_lib_url}/${wasm_lib}" -O "${wasm_lib_path}" && chmod +r "${wasm_lib_path}"
         wget "${wasm_lib_url}/checksums.txt" -O /tmp/checksums.txt
         sha256sum "${wasm_lib_path}" | grep "$(< /tmp/checksums.txt grep "${wasm_lib}" | cut -d ' ' -f 1)"
+        echo "${wasmvm_lib_version}" > "${wasm_version_marker}"
     else
         msg "wasm library already downloaded"
     fi

--- a/scripts/node.sh
+++ b/scripts/node.sh
@@ -72,7 +72,7 @@ die() {
 parse_params() {
   # default values of variables set from params
   axelar_core_version=""
-  wasmvm_lib_version="v1.5.8"
+  wasmvm_lib_version=""
   reset_chain=0
   root_directory=''
   git_root="$(git rev-parse --show-toplevel)"
@@ -122,6 +122,10 @@ parse_params() {
       node_moniker="${2-}"
       shift
       ;;
+    -w | --wasmvm-lib-version)
+      wasmvm_lib_version="${2-}"
+      shift
+      ;;
     -?*) die "Unknown option: $1" ;;
     *) break ;;
     esac
@@ -159,6 +163,10 @@ parse_params() {
 
   if [ -z "${axelar_core_version}" ]; then
     axelar_core_version="$(fetch_axelar_core_version "${network}")"
+  fi
+
+  if [ -z "${wasmvm_lib_version}" ]; then
+    wasmvm_lib_version="$(fetch_wasmvm_version "${axelar_core_version}")"
   fi
 
   # check required params and arguments
@@ -313,6 +321,7 @@ setup_colors
 msg "${RED}Read parameters:${NOFORMAT}"
 msg "- reset-chain: ${reset_chain}"
 msg "- axelar-core-version: ${axelar_core_version}"
+msg "- wasmvm-lib-version: ${wasmvm_lib_version}"
 msg "- root-directory: ${root_directory}"
 msg "- tendermint-key-path: ${tendermint_key_path}"
 msg "- axelar-mnemonic-path: ${axelar_mnemonic_path}"

--- a/scripts/setup-host.sh
+++ b/scripts/setup-host.sh
@@ -81,15 +81,16 @@ download_dependencies() {
     if [[ "$arch" == "amd64" ]]; then wasm_lib="libwasmvm.x86_64.so"; fi
 
     wasm_lib_path="${share_lib_directory}/${wasm_lib}"
-    wasmvm_lib_version="v1.5.8"
+    local wasm_version_marker="${share_lib_directory}/.wasmvm_version"
     msg "downloading wasm shared library ${wasmvm_lib_version}/${wasm_lib}"
 
-    if [[ ! -f "${wasm_lib_path}" ]]; then
+    if [[ ! -f "${wasm_lib_path}" ]] || [[ ! -f "${wasm_version_marker}" ]] || [[ "$(cat "${wasm_version_marker}")" != "${wasmvm_lib_version}" ]]; then
         local wasm_lib_url
         wasm_lib_url="https://github.com/CosmWasm/wasmvm/releases/download/${wasmvm_lib_version}"
         wget "${wasm_lib_url}/${wasm_lib}" -O "${wasm_lib_path}" && chmod +r "${wasm_lib_path}"
         wget "${wasm_lib_url}/checksums.txt" -O /tmp/checksums.txt
         sha256sum "${wasm_lib_path}" | grep "$(< /tmp/checksums.txt grep "${wasm_lib}" | cut -d ' ' -f 1)"
+        echo "${wasmvm_lib_version}" > "${wasm_version_marker}"
     else
         msg "wasm library already downloaded"
     fi

--- a/scripts/setup-node.sh
+++ b/scripts/setup-node.sh
@@ -31,7 +31,7 @@ EOF
 parse_params() {
     # default values of variables set from params
     axelar_core_version=""
-    wasmvm_lib_version="v1.5.8"
+    wasmvm_lib_version=""
     reset_chain=0
     root_directory=''
     git_root="$(git rev-parse --show-toplevel)"
@@ -61,6 +61,10 @@ parse_params() {
             ;;
         -e | --environment)
             environment="${2-}"
+            shift
+            ;;
+        -w | --wasmvm-lib-version)
+            wasmvm_lib_version="${2-}"
             shift
             ;;
         --skip-download)
@@ -96,6 +100,10 @@ parse_params() {
 
     if [ -z "${axelar_core_version}" ]; then
         axelar_core_version="$(fetch_axelar_core_version "${network}")"
+    fi
+
+    if [ -z "${wasmvm_lib_version}" ]; then
+        wasmvm_lib_version="$(fetch_wasmvm_version "${axelar_core_version}")"
     fi
 
     # check required params and arguments
@@ -197,6 +205,7 @@ setup_colors
 msg "${RED}Read parameters:${NOFORMAT}"
 msg "- reset-chain: ${reset_chain}"
 msg "- axelar-core-version: ${axelar_core_version}"
+msg "- wasmvm-lib-version: ${wasmvm_lib_version}"
 msg "- root-directory: ${root_directory}"
 msg "- network: ${network}"
 msg "- environment: ${environment}"

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -139,6 +139,24 @@ fetch_tofnd_version() {
     echo "$version"
 }
 
+# Fetch the wasmvm version matching a given axelar-core release from go.sum
+fetch_wasmvm_version() {
+    local axelar_core_version="$1"
+    local response
+    if ! response="$(curl -s --fail --max-time 15 "https://raw.githubusercontent.com/axelarnetwork/axelar-core/${axelar_core_version}/go.sum" 2>/dev/null)"; then
+        die "Failed to fetch go.sum for axelar-core ${axelar_core_version}. Please retry or provide the wasmvm version manually via the --wasmvm-lib-version flag."
+    fi
+
+    local version
+    version="$(echo "$response" | grep 'github.com/CosmWasm/wasmvm' | grep -v '/go.mod' | head -1 | awk '{print $2}')"
+
+    if [ -z "$version" ]; then
+        die "Could not parse wasmvm version from go.sum. Please retry or provide the wasmvm version manually via the --wasmvm-lib-version flag."
+    fi
+
+    echo "$version"
+}
+
 check_signature() {
     sig_url="$1"
     sig_path="$2"


### PR DESCRIPTION
**Summary**

- Replace the hardcoded wasmvm v1.5.8 with a dynamic lookup against axelar-core's go.sum, ensuring the correct wasmvm library is always downloaded for the chosen axelar-core release
- Add --wasmvm-lib-version / -w flag to node.sh and setup-node.sh for manual override
- Re-download the wasm library when the version changes, instead of skipping the download if any version of the file already exists

**Motivation**

Running `setup-validator.sh` failed for me. This is because the wasmvm version was hardcoded to an older v1.5.8. I updated the script to fetch the correct version. Though my next run still failed, because it kept using the old version, leading to runtime incompatibilities. These changes make the scripts to fetch the correct wasmvm version and override if a wrong version is found.

**Changes**

- scripts/utils.sh: Add fetch_wasmvm_version() that fetches go.sum from the axelar-core release tag and extracts the CosmWasm/wasmvm version
- scripts/node.sh, scripts/setup-node.sh: Remove hardcoded default, auto-fetch wasmvm version after resolving axelar-core version, add -w/--wasmvm-lib-version flag
- scripts/host.sh, scripts/setup-host.sh: Track downloaded wasmvm version in a .wasmvm_version marker file and re-download when it changes