### PR TITLE
chore: set timeout_propose to 1s

### DIFF
--- a/configuration/config.toml
+++ b/configuration/config.toml
@@ -343,7 +343,7 @@ version = "v0"
 wal_file = "data/cs.wal/wal"
 
 # How long we wait for a proposal block before prevoting nil
-timeout_propose = "3s"
+timeout_propose = "1s"
 # How much timeout_propose increases with each round
 timeout_propose_delta = "500ms"
 # How long we wait after receiving +2/3 prevotes for “anything” (ie. not a single block or nil)


### PR DESCRIPTION
In alert [23YELLOW9DEC2025] we asked all validators to use:

[consensus]
timeout_propose = "1s"
timeout_commit = “1s”

But the default/example toml file is still reporting the old value. Fixing.

Part of CPI-314